### PR TITLE
Add conversion from action and observation space to gym spaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Change Log
 
 [1.1.2] - 2020-XX-XX
 ---------------------
+- [ADDED] `ActionSpace.sample` method is now implemented
 - [ADDED] DeltaRedispatchRandomAgent: that takes redispatching actions of a configurable [-delta;+delta] in MW on random generators.
 - [FIXED] `Issue #129<https://github.com/rte-france/Grid2Op/issues/129>`_: game over count for env_actions
 - [FIXED] `Issue #127 <https://github.com/rte-france/Grid2Op/issues/127>`_: Removed no longer existing attribute docstring `indisponibility`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,16 @@ Change Log
 - [???] model batteries / pumped storage in grid2op (generator but that can be charged / discharged)
 - [???] model dumps (as in dump storage) in grid2op (stuff that have a given energy max, and cannot produce more than the available energy)
 
+[1.1.2] - 2020-XX-XX
+---------------------
+- [ADDED] DeltaRedispatchRandomAgent: that takes redispatching actions of a configurable [-delta;+delta] in MW on random generators.
+- [FIXED] `Issue #129<https://github.com/rte-france/Grid2Op/issues/129>`_: game over count for env_actions
+- [FIXED] `Issue #127 <https://github.com/rte-france/Grid2Op/issues/127>`_: Removed no longer existing attribute docstring `indisponibility`
+- [FIXED] `Issue #133 <https://github.com/rte-france/Grid2Op/issues/133>`_: Missing positional argument `space_prng` in `Action.SerializableActionSpace`
+- [FIXED] `Issue #131 <https://github.com/rte-france/Grid2Op/issues/131>`_: Forecast values are accessible without needing to call `obs.simulate` beforehand.
+- [FIXED] `Issue #134 <https://github.com/rte-france/Grid2Op/issues/134>`_: Backend iadd actions with lines extremities disconnections (set -1)
+- [FIXED] issue `Issue 122 <https://github.com/rte-france/Grid2Op/issues/125>`_
+
 [1.1.1] - 2020-07-07
 ---------------------
 - [FIXED] the EpisodeData now properly propagates the end of the episode

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Change Log
 - [FIXED] `Issue #134 <https://github.com/rte-france/Grid2Op/issues/134>`_: Backend iadd actions with lines extremities disconnections (set -1)
 - [FIXED] issue `Issue #125 <https://github.com/rte-france/Grid2Op/issues/125>`_
 - [FIXED] issue `Issue #126 <https://github.com/rte-france/Grid2Op/issues/126>`_ Loading runner logs no longer checks environment actions ambiguity
+- [IMPROVED] issue `Issue #16 <https://github.com/rte-france/Grid2Op/issues/16>`_ improving openai gym integration.
+
 
 [1.1.1] - 2020-07-07
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Change Log
 - [FIXED] `Issue #133 <https://github.com/rte-france/Grid2Op/issues/133>`_: Missing positional argument `space_prng` in `Action.SerializableActionSpace`
 - [FIXED] `Issue #131 <https://github.com/rte-france/Grid2Op/issues/131>`_: Forecast values are accessible without needing to call `obs.simulate` beforehand.
 - [FIXED] `Issue #134 <https://github.com/rte-france/Grid2Op/issues/134>`_: Backend iadd actions with lines extremities disconnections (set -1)
-- [FIXED] issue `Issue 122 <https://github.com/rte-france/Grid2Op/issues/125>`_
+- [FIXED] issue `Issue #125 <https://github.com/rte-france/Grid2Op/issues/125>`_
+- [FIXED] issue `Issue #126 <https://github.com/rte-france/Grid2Op/issues/126>`_ Loading runner logs no longer checks environment actions ambiguity
 
 [1.1.1] - 2020-07-07
 ---------------------

--- a/grid2op/Action/BaseAction.py
+++ b/grid2op/Action/BaseAction.py
@@ -1430,27 +1430,6 @@ class BaseAction(GridObjects):
             if self.shunt_bus is not None:
                 raise AmbiguousAction("Attempt to modify a shunt (shunt_bus) while shunt data is not handled by backend")
 
-    def sample(self, space_prng):
-        """
-        This method is used to sample action.
-
-        A generic sampling of action can be really tedious. Uniform sampling is almost impossible.
-        The actual implementation gives absolutely no warranty toward any of these concerns.
-
-        **It is not implemented yet.**
-
-        By calling :func:`Action.sample`, the action is :func:`Action.reset` to a "do nothing" state. If you want
-        to sample uniformly at random among some actions, we recommand you the use of the converter IdToAct that
-        implements this feature.
-
-        Returns
-        -------
-        self: :class:`BaseAction`
-            The action sampled among the action space.
-        """
-        self.reset()
-        return self
-
     def _ignore_topo_action_if_disconnection(self, sel_):
         # force ignore of any topological actions
         self._set_topo_vect[np.array(self.line_or_pos_topo_vect[sel_])] = 0

--- a/grid2op/Action/SerializableActionSpace.py
+++ b/grid2op/Action/SerializableActionSpace.py
@@ -74,10 +74,9 @@ class SerializableActionSpace(SerializableSpace):
 
     def sample(self):
         """
-        A utility used to sample :class:`Action`.
+        A utility used to sample a new random :class:`Action`.
 
-        This method is under development, use with care (actions are not sampled on the full action space, and are
-        not uniform in general).
+        NOT IMPLEMENTED
 
         Returns
         -------
@@ -85,8 +84,12 @@ class SerializableActionSpace(SerializableSpace):
             A random action sampled from the :attr:`ActionSpace.actionClass`
 
         """
-        res = self.actionClass()  # only the GridObjects part of "self" is actually used
-        res.sample()
+        res = self.actionClass() # Create empty action of this space type
+        res.reset() # Set to do nothing
+        # TODO: Implement random action sampling
+        # switch_line_id = self.space_prng.randint(self.n_line)
+        # switch_sub_id = self.space_prng.randint(self.n_sub)
+        # .. etc
         return res
 
     def disconnect_powerline(self, line_id=None, line_name=None, previous_action=None):

--- a/grid2op/Action/SerializableActionSpace.py
+++ b/grid2op/Action/SerializableActionSpace.py
@@ -76,7 +76,8 @@ class SerializableActionSpace(SerializableSpace):
         """
         A utility used to sample a new random :class:`Action`.
 
-        NOT IMPLEMENTED
+        The sampled action is unitary: 
+        It has an impact on a single line/substation/generator.
 
         Returns
         -------
@@ -84,13 +85,68 @@ class SerializableActionSpace(SerializableSpace):
             A random action sampled from the :attr:`ActionSpace.actionClass`
 
         """
-        res = self.actionClass() # Create empty action of this space type
-        res.reset() # Set to do nothing
-        # TODO: Implement random action sampling
-        # switch_line_id = self.space_prng.randint(self.n_line)
-        # switch_sub_id = self.space_prng.randint(self.n_sub)
-        # .. etc
-        return res
+        rnd_act = self.actionClass()
+        
+        rnd_types = []
+        if "set_line_status" in self.actionClass.authorized_keys:
+            rnd_types.append(0)
+        if "change_line_status" in self.actionClass.authorized_keys:
+            rnd_types.append(1)
+        if "set_bus" in self.actionClass.authorized_keys:
+            rnd_types.append(2)
+        if "change_bus" in self.actionClass.authorized_keys:
+            rnd_types.append(3)
+        if "redispatch" in self.actionClass.authorized_keys:
+            rnd_types.append(4)
+
+        # Cannot sample this space, return do nothing
+        if not len(rnd_types):
+            return rnd_act
+
+        rnd_type = self.space_prng.choice(rnd_types)
+        if rnd_type == 0:
+            rnd_line = self.space_prng.randint(self.n_line)
+            rnd_status = self.space_prng.choice([1, -1])
+            rnd_update = {
+                "set_line_status": [(rnd_line, rnd_status)]
+            }
+        elif rnd_type == 1:
+            rnd_line = self.space_prng.randint(self.n_line)
+            rnd_update = {
+                "change_line_status": [rnd_line]
+            }
+        elif rnd_type == 2:
+            rnd_sub = self.space_prng.randint(self.n_sub)
+            sub_size = self.sub_info[rnd_sub]
+            rnd_topo = self.space_prng.choice([-1, 0, 1, 2], sub_size)
+            rnd_update = {
+                "set_bus": {
+                    "substations_id": [(rnd_sub, rnd_topo)]
+                }
+            }
+        elif rnd_type == 3:
+            rnd_sub = self.space_prng.randint(self.n_sub)
+            sub_size = self.sub_info[rnd_sub]
+            rnd_topo = self.space_prng.choice([0, 1], sub_size)
+            rnd_update = {
+                "change_bus": {
+                    "substations_id": [(rnd_sub, rnd_topo)]
+                }
+            }
+        else:
+            gens = np.arange(self.n_gen)[self.gen_redispatchable]
+            rnd_gen = self.space_prng.choice(gens)
+            ru = -self.gen_max_ramp_down[rnd_gen]
+            rd = self.gen_max_ramp_up[rnd_gen]
+            rnd_gen_disp = (ru - rd) * self.space_prng.random() + rd
+            rnd_disp = np.zeros(self.n_gen)
+            rnd_disp[rnd_gen] = rnd_gen_disp
+            rnd_update = {
+                "redispatch" : rnd_disp
+            }
+
+        rnd_act.update(rnd_update)
+        return rnd_act
 
     def disconnect_powerline(self, line_id=None, line_name=None, previous_action=None):
         """

--- a/grid2op/Action/_BackendAction.py
+++ b/grid2op/Action/_BackendAction.py
@@ -220,6 +220,9 @@ class _BackendAction(GridObjects):
         #     self.shunt_q.all_changed()
         #     self.shunt_bus.all_changed()
 
+    def set_redispatch(self, new_redispatching):
+        self.prod_p.change_val(new_redispatching)
+
     def __iadd__(self, other):
         """
         other: a grid2op action standard

--- a/grid2op/Action/_BackendAction.py
+++ b/grid2op/Action/_BackendAction.py
@@ -81,13 +81,13 @@ class ValueStore:
         self.values[reco_or] = old_vect[reco_or]
         self.values[reco_ex] = old_vect[reco_ex]
 
-    def set_status(self, set, lineor_id, lineex_id, old_vect):
+    def set_status(self, set_status, lineor_id, lineex_id, old_vect):
         id_or = lineor_id
         id_ex = lineex_id
 
         # disco
-        disco_ = set == -1
-        reco_ = set == 1
+        disco_ = set_status == -1
+        reco_ = set_status == 1
 
         # make it to ids
         id_reco_or = id_or[reco_]
@@ -178,6 +178,8 @@ class _BackendAction(GridObjects):
 
         self._status_or_before = np.ones(self.n_line, dtype=dt_int)
         self._status_ex_before = np.ones(self.n_line, dtype=dt_int)
+        self._status_or = np.ones(self.n_line, dtype=dt_int)
+        self._status_ex = np.ones(self.n_line, dtype=dt_int)
 
     def reset(self):
         # last topo
@@ -282,19 +284,35 @@ class _BackendAction(GridObjects):
                                      self.line_ex_pos_topo_vect,
                                      self.last_topo_registered)
 
-        self._status_or_before[:], self._status_ex_before[:] = self.current_topo.get_line_status(self.line_or_pos_topo_vect,
-                                                                                                 self.line_ex_pos_topo_vect)
+        topo_before = self.current_topo.values
+        self._status_or_before[:], \
+        self._status_ex_before[:] = self.current_topo.get_line_status(
+            self.line_or_pos_topo_vect,
+            self.line_ex_pos_topo_vect)
+
         # IV topo
         self.current_topo.change_val(switcth_topo_vect)
         self.current_topo.set_val(set_topo_vect)
 
-        # V Force disconnection of disconnected powerlines
-        disco_before_topo = (self._status_or_before == -1) | (self._status_ex_before == -1)
-        self.current_topo.set_status(self._status_or_before[disco_before_topo],
-                                     self.line_or_pos_topo_vect[disco_before_topo],
-                                     self.line_ex_pos_topo_vect[disco_before_topo],
-                                     self._status_or_before[disco_before_topo]  # unused
-                                     )
+        # V Force disconnected status
+        # of disconnected powerlines extremities
+        self._status_or[:], \
+        self._status_ex[:] = self.current_topo.get_line_status(
+            self.line_or_pos_topo_vect,
+            self.line_ex_pos_topo_vect)
+
+        # At least one disconnected extremity
+        disco_or = (self._status_or_before == -1) | (self._status_or == -1)
+        disco_ex = (self._status_ex_before == -1) | (self._status_ex == -1)
+        disco_now = disco_or & disco_ex
+        # Set nothing
+        set_now = np.zeros_like(self._status_or)
+        # Force some disconnections
+        set_now[disco_now] = -1
+        self.current_topo.set_status(set_now,
+                                     self.line_or_pos_topo_vect,
+                                     self.line_ex_pos_topo_vect,
+                                     self.last_topo_registered)
 
         return self
 

--- a/grid2op/Agent/DeltaRedispatchRandomAgent.py
+++ b/grid2op/Agent/DeltaRedispatchRandomAgent.py
@@ -1,0 +1,77 @@
+import numpy as np
+from grid2op.Agent import BaseAgent
+
+class DeltaRedispatchRandomAgent(BaseAgent):        
+    def __init__(self, action_space,
+                 n_gens_to_redispatch=2,
+                 redispatching_delta=1.0):
+        """
+        Agent constructor
+
+        Parameters
+        ----------
+        :action_space: :class:`grid2op.Action.ActionSpace`
+             the Grid2Op action space
+
+        :n_gens_to_redispatch: `int`
+          The maximum number of dispatchable generators to play with 
+
+        :redispatching_delta: `float`
+          The redispatching MW value used in both directions
+        """
+        super().__init__(action_space)
+        self.desired_actions = []
+
+        # Get all generators IDs
+        gens_ids = np.arange(self.action_space.n_gen, dtype=int)
+        # Filter out non resipatchable IDs
+        gens_redisp = gens_ids[self.action_space.gen_redispatchable]
+        # Cut if needed
+        if len(gens_redisp) > n_gens_to_redispatch:
+            gens_redisp = gens_redisp[0:n_gens_to_redispatch]
+
+        # Register do_nothing action
+        self.desired_actions.append(self.action_space({}))
+
+        # Register 2 actions per generator
+        # (increase or decrease by the delta)
+        for gen_id in gens_redisp:
+            # Create action redispatch by opposite delta
+            act1 = self.action_space({
+                "redispatch": [
+                    (gen_id, -float(redispatching_delta))
+                ]
+            })
+            
+            # Create action redispatch by delta
+            act2 = self.action_space({
+                "redispatch": [
+                    (gen_id, float(redispatching_delta))
+                ]
+            })
+
+            # Register this generator actions
+            self.desired_actions.append(act1)
+            self.desired_actions.append(act2)
+
+        
+    def act(self, observation, reward, done=False):
+        """
+        Parameters
+        ----------
+        observation: :class:`grid2op.Observation.Observation`
+            The current observation of the 
+            :class:`grid2op.Environment.Environment`
+        reward: ``float``
+            The current reward. 
+            This is the reward obtained by the previous action
+        done: ``bool``
+            Whether the episode has ended or not. 
+            Used to maintain gym compatibility
+        Returns
+        -------
+        res: :class:`grid2op.Action.Action`
+            The action chosen by agent.
+        """
+        
+        return self.space_prng.choice(self.desired_actions)

--- a/grid2op/Agent/__init__.py
+++ b/grid2op/Agent/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "TopologyGreedy",
     "AgentWithConverter",
     "RandomAgent",
+    "DeltaRedispatchRandomAgent",
     "MLAgent",
     "RecoPowerlineAgent"
 ]
@@ -19,5 +20,6 @@ from grid2op.Agent.PowerlineSwitch import PowerLineSwitch
 from grid2op.Agent.TopologyGreedy import TopologyGreedy
 from grid2op.Agent.AgentWithConverter import AgentWithConverter
 from grid2op.Agent.RandomAgent import RandomAgent
+from grid2op.Agent.DeltaRedispatchRandomAgent import DeltaRedispatchRandomAgent
 from grid2op.Agent.MLAgent import MLAgent
 from grid2op.Agent.RecoPowerlineAgent import RecoPowerlineAgent

--- a/grid2op/Converter/AnalogStateConverter.py
+++ b/grid2op/Converter/AnalogStateConverter.py
@@ -18,6 +18,10 @@ class AnalogStateConverter(Converter):
     
     The grid2op observation is converted into a 1d normalied array
     The grid2op action is created from a set of real valued arrays
+
+    It can not yet be converted to / from gym space. If this feature is interesting for you, you can
+    reply to the issue posted at https://github.com/rte-france/Grid2Op/issues/16
+    
     """
 
     def __init__(self, action_space, bias=0.0):

--- a/grid2op/Converter/ConnectivityConverter.py
+++ b/grid2op/Converter/ConnectivityConverter.py
@@ -21,6 +21,9 @@ class ConnectivityConverter(Converter):
     A and B", connect "B and C" but "**not connect** A and C" in this case you need an algorithm to disambuate your
     action.
 
+    It can not yet be converted to / from gym space. If this feature is interesting for you, you can
+    reply to the issue posted at https://github.com/rte-france/Grid2Op/issues/16
+
     **NB** compare to :class:`IdToAct` this converter allows for a smaller size. If you have N elements connected at
     a substation, you end up with `N*(N-1)/2` different action. Compare to IdToAct though, it is expected that your
     algorithm produces more than 1 output.

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -14,7 +14,6 @@ class Converter(ActionSpace):
     """
     def __init__(self, action_space):
         ActionSpace.__init__(self, action_space, action_space.legal_action, action_space.subtype)
-        # self.__class__ = Converter.init_grid(action_space)
         self.space_prng = action_space.space_prng
         self.seed_used = action_space.seed_used
 

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -76,11 +76,83 @@ class Converter(ActionSpace):
                                   "".format(self))
 
     def convert_action_from_gym(self, gymlike_action):
+        """
+        Convert the action (represented as a gym object, in fact an ordered dict) as an action
+        compatible with this converter.
+
+        This is not compatible with all converters and you need to install gym for it to work.
+
+        Parameters
+        ----------
+        gymlike_action:
+            the action to be converted to an action compatible with the action space representation
+
+        Returns
+        -------
+        res:
+            The action converted to be understandable by this converter.
+
+        Examples
+        ---------
+        Here is an example on how to use this feature with the :class:`grid2op.Converter.IdToAct`
+        converter (imports are not shown here).
+
+        .. code-block:: python
+
+            # create the environment
+            env = grid2op.make()
+
+            # create the converter
+            converter = IdToAct(env.action_space)
+
+            # create the gym action space
+            gym_action_space = GymObservationSpace(action_space=converter)
+
+            gym_action = gym_action_space.sample()
+            converter_action = converter.convert_action_from_gym(gym_action)  # this represents the same action
+            grid2op_action = converter.convert_act(converter_action)
+
+        """
         raise NotImplementedError("Impossible to convert the gym-like action automatically "
                                   "into the converter representation for \"{}\" "
                                   "".format(self))
 
-    def convert_action_to_gym(self, gymlike_action):
+    def convert_action_to_gym(self, action):
+        """
+        Convert the action (compatible with this converter) into a "gym action" (ie an OrderedDict)
+
+        This is not compatible with all converters and you need to install gym for it to work.
+
+        Parameters
+        ----------
+        action:
+            the action to be converted to an action compatible with the action space representation
+
+        Returns
+        -------
+        res:
+            The action converted to a "gym" model (can be used by a machine learning model)
+
+        Examples
+        ---------
+        Here is an example on how to use this feature with the :class:`grid2op.Converter.IdToAct`
+        converter (imports are not shown here).
+
+        .. code-block:: python
+
+            # create the environment
+            env = grid2op.make()
+
+            # create the converter
+            converter = IdToAct(env.action_space)
+
+            # create the gym action space
+            gym_action_space = GymObservationSpace(action_space=converter)
+
+            converter_action = converter.sample()
+            gym_action = converter.to_gym(converter_action)  # this represents the same action
+
+        """
         raise NotImplementedError("Impossible to convert the gym-like action automatically "
                                   "into the converter representation for \"{}\" "
                                   "".format(self))

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -63,13 +63,15 @@ class Converter(ActionSpace):
 
     def get_gym_dict(self):
         """
-        To convert this space into a open ai gym space.
+        To convert this space into a open ai gym space. This function returns a dictionnary used
+        to initialize such a converter.
 
-        # TODO
+        It should not be used directly. Prefer to use the :class:`grid2op.Converter.GymConverter`
 
         Returns
         -------
-
+        res: ``dict``
+            The dictionary of gym spaces representing this converter.
         """
         raise NotImplementedError("Impossible to convert the converter \"{}\" automatically "
                                   "into a gym space (or gym is not installed on your machine)."

--- a/grid2op/Converter/Converters.py
+++ b/grid2op/Converter/Converters.py
@@ -60,3 +60,27 @@ class Converter(ActionSpace):
         """
         regular_act = encoded_act
         return regular_act
+
+    def get_gym_dict(self):
+        """
+        To convert this space into a open ai gym space.
+
+        # TODO
+
+        Returns
+        -------
+
+        """
+        raise NotImplementedError("Impossible to convert the converter \"{}\" automatically "
+                                  "into a gym space (or gym is not installed on your machine)."
+                                  "".format(self))
+
+    def convert_action_from_gym(self, gymlike_action):
+        raise NotImplementedError("Impossible to convert the gym-like action automatically "
+                                  "into the converter representation for \"{}\" "
+                                  "".format(self))
+
+    def convert_action_to_gym(self, gymlike_action):
+        raise NotImplementedError("Impossible to convert the gym-like action automatically "
+                                  "into the converter representation for \"{}\" "
+                                  "".format(self))

--- a/grid2op/Converter/GymConverter.py
+++ b/grid2op/Converter/GymConverter.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import numpy as np
+from grid2op.Converter.Converters import Converter
+from grid2op.Action import BaseAction
+from grid2op.Observation import BaseObservation
+from grid2op.dtypes import dt_int, dt_bool, dt_float
+from gym import spaces
+
+
+class BaseGymConverter:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def _generic_gym_space(dt, sh, low=None, high=None):
+        if low is None:
+            low = np.iinfo(dt).min
+        if high is None:
+            high = np.iinfo(dt).max
+        shape = (sh,)
+        my_type = spaces.Box(low=dt.type(low), high=dt.type(high), shape=shape, dtype=dt)
+        return my_type
+
+    @staticmethod
+    def _boolean_type(sh):
+        return spaces.MultiBinary(n=sh)
+
+    @staticmethod
+    def _extract_obj_grid2op(grid2op_obj, attr_nm, dtype):
+        res = grid2op_obj._get_array_from_attr_name(attr_nm)
+
+        if len(res) == 1:
+            res = res[0]
+            # convert the types for json serializable
+            # this is not automatically done by gym...
+            if dtype == dt_int or dtype == np.int64 or dtype == np.int32:
+                res = int(res)
+            elif dtype == dt_float or dtype == np.float64 or dtype == np.float32:
+                res = float(res)
+            elif dtype == dt_bool:
+                res = bool(res)
+        return res
+
+    def _base_to_gym(self, keys, obj, dtypes, converter=None):
+        res = spaces.dict.OrderedDict()
+        for k in keys:
+            conv_k = k
+            if converter is not None:
+                conv_k = converter[k]
+            res[k] = self._extract_obj_grid2op(obj, conv_k, dtypes[k])
+        return res
+
+
+class GymObservationSpace(spaces.Dict, BaseGymConverter):
+    # deals with the observation space (rather easy)
+    def __init__(self, env):
+        self.initial_obs_space = env.observation_space
+        dict_ = {}
+        self._fill_dict_obs_space(dict_, env.observation_space, env.parameters)
+        spaces.Dict.__init__(self, dict_)
+
+    def _fill_dict_obs_space(self, dict_, observation_space, env_params):
+        for attr_nm, sh, dt in zip(observation_space.attr_list_vect,
+                                   observation_space.shape,
+                                   observation_space.dtype):
+            my_type = None
+            shape = (sh,)
+            if dt == dt_int:
+                # discrete observation space
+                if attr_nm == "year":
+                    my_type = spaces.Discrete(n=2100)
+                elif attr_nm == "month":
+                    my_type = spaces.Discrete(n=13)
+                elif attr_nm == "day":
+                    my_type = spaces.Discrete(n=32)
+                elif attr_nm == "hour_of_day":
+                    my_type = spaces.Discrete(n=24)
+                elif attr_nm == "minute_of_hour":
+                    my_type = spaces.Discrete(n=60)
+                elif attr_nm == "day_of_week":
+                    my_type = spaces.Discrete(n=8)
+                elif attr_nm == "topo_vect":
+                    my_type = spaces.Box(low=0, high=2, shape=shape, dtype=dt)
+                elif attr_nm == "time_before_cooldown_line":
+                    my_type = spaces.Box(low=0,
+                                         high=max(env_params.NB_TIMESTEP_COOLDOWN_LINE,
+                                                  env_params.NB_TIMESTEP_RECONNECTION),
+                                         shape=shape,
+                                         dtype=dt)
+                elif attr_nm == "time_before_cooldown_sub":
+                    my_type = spaces.Box(low=0,
+                                         high=env_params.NB_TIMESTEP_COOLDOWN_SUB,
+                                         shape=shape,
+                                         dtype=dt)
+                elif attr_nm == "duration_next_maintenance" or attr_nm == "time_next_maintenance":
+                    # can be -1 if no maintenance, otherwise always positive
+                    my_type = self._generic_gym_space(dt, sh, low=-1)
+
+            elif dt == dt_bool:
+                # boolean observation space
+                my_type = self._boolean_type(sh)
+            else:
+                # continuous observation space
+                low = float("-inf")
+                high = float("inf")
+                shape = (sh,)
+                SpaceType = spaces.Box
+                if attr_nm == "prod_p":
+                    low = observation_space.gen_pmin
+                    high = observation_space.gen_pmax
+                    shape = None
+                elif attr_nm == "prod_v" or attr_nm == "load_v" or attr_nm == "v_or" or attr_nm == "v_ex":
+                    # voltages can't be negative
+                    low = 0.
+                elif attr_nm == "a_or" or attr_nm == "a_ex":
+                    # amps can't be negative
+                    low = 0.
+                elif attr_nm == "target_dispatch" or attr_nm == "actual_dispatch":
+                    low = np.min([observation_space.gen_pmin,
+                                  -observation_space.gen_pmax])
+                    high = np.max([-observation_space.gen_pmin,
+                                   +observation_space.gen_pmax])
+                my_type = SpaceType(low=low, high=high, shape=shape, dtype=dt)
+
+            if my_type is None:
+                # if nothing has been found in the specific cases above
+                my_type = self._generic_gym_space(dt, sh)
+
+            dict_[attr_nm] = my_type
+
+    def from_gym(self, gymlike_observation: spaces.dict.OrderedDict) -> BaseObservation:
+        res = self.initial_obs_space.get_empty_observation()
+        for k, v in gymlike_observation.items():
+            res._assign_attr_from_name(k, v)
+        return res
+
+    def to_gym(self, grid2op_observation: BaseObservation) -> spaces.dict.OrderedDict:
+        return self._base_to_gym(self.spaces.keys(), grid2op_observation,
+                                 dtypes={k: self.spaces[k].dtype for k in self.spaces})
+
+
+class GymActionSpace(spaces.Dict, BaseGymConverter):
+    # deals with the action space (it depends how it's encoded...)
+    keys_grid2op_2_human = {"prod_p": "prod_p",
+                            "prod_v": "prod_v",
+                            "load_p": "load_p",
+                            "load_q": "load_q",
+                            "_redispatch": "redispatch",
+                            "_set_line_status": "set_line_status",
+                            "_switch_line_status": "change_line_status",
+                            "_set_topo_vect": "set_bus",
+                            "_change_bus_vect": "change_bus",
+                            "_hazards": "hazards",
+                            "_maintenance": "maintenance",
+                            }
+    keys_human_2_grid2op = {v: k for k, v in keys_grid2op_2_human.items()}
+
+    def __init__(self, action_space):
+        self.initial_act_space = action_space
+        dict_ = {}
+        if isinstance(action_space, Converter):
+            # a converter allows to ... convert the data so they have specific gym space
+            dict_ = action_space.get_gym_dict()
+            self.__is_converter = True
+        else:
+            self._fill_dict_act_space(dict_, action_space)
+            dict_ = self._fix_dict_keys(dict_)
+            self.__is_converter = False
+
+        spaces.Dict.__init__(self, dict_)
+
+    def _fill_dict_act_space(self, dict_, action_space):
+        for attr_nm, sh, dt in zip(action_space.attr_list_vect,
+                                   action_space.shape,
+                                   action_space.dtype):
+            my_type = None
+            shape = (sh,)
+            if dt == dt_int:
+                # discrete action space
+                if attr_nm == "_set_line_status":
+                    my_type = spaces.Box(low=-1,
+                                         high=1,
+                                         shape=shape,
+                                         dtype=dt)
+                elif attr_nm == "_set_topo_vect":
+                    my_type = spaces.Box(low=-1,
+                                         high=2,
+                                         shape=shape,
+                                         dtype=dt)
+            elif dt == dt_bool:
+                # boolean observation space
+                my_type = self._boolean_type(sh)
+                # case for all "change" action and maintenance / hazards
+            else:
+                # continuous observation space
+                low = float("-inf")
+                high = float("inf")
+                shape = (sh,)
+                SpaceType = spaces.Box
+
+                if attr_nm == "prod_p":
+                    low = action_space.gen_pmin
+                    high = action_space.gen_pmax
+                    shape = None
+                elif attr_nm == "prod_v":
+                    # voltages can't be negative
+                    low = 0.
+                elif attr_nm == "_redispatch":
+                    # redispatch
+                    low = -action_space.gen_max_ramp_down
+                    high = action_space.gen_max_ramp_up
+                my_type = SpaceType(low=low, high=high, shape=shape, dtype=dt)
+
+            if my_type is None:
+                # if nothing has been found in the specific cases above
+                my_type = self._generic_gym_space(dt, sh)
+
+            dict_[attr_nm] = my_type
+
+    def _fix_dict_keys(self, dict_: dict) -> dict:
+        res = {}
+        for k, v in dict_.items():
+            res[self.keys_grid2op_2_human[k]] = v
+        return res
+
+    def from_gym(self, gymlike_action: spaces.dict.OrderedDict) -> object:
+        """
+        Transform a gym-like action (such as the output of "sample()") into a grid2op action
+
+        Parameters
+        ----------
+        gymlike_action
+
+        Returns
+        -------
+
+        """
+        if self.__is_converter:
+            res = self.initial_act_space.convert_action_from_gym(gymlike_action)
+        else:
+            res = self.initial_act_space()
+            for k, v in gymlike_action.items():
+                res._assign_attr_from_name(self.keys_human_2_grid2op[k], v)
+        return res
+
+    def to_gym(self, action: object) -> spaces.dict.OrderedDict:
+        """
+        Transform an action (non gym) into an action compatible with the gym Space.
+
+        Parameters
+        ----------
+        action
+
+        Returns
+        -------
+
+        """
+        if self.__is_converter:
+            res = self.initial_act_space.convert_action_to_gym(action)
+        else:
+            # in that case action should be an instance of grid2op BaseAction
+            assert isinstance(action, BaseAction), "impossible to convert an action not coming from grid2op"
+            res = self._base_to_gym(self.spaces.keys(), action,
+                                    dtypes={k: self.spaces[k].dtype for k in self.spaces},
+                                    converter=self.keys_human_2_grid2op)
+        return res

--- a/grid2op/Converter/IdToAct.py
+++ b/grid2op/Converter/IdToAct.py
@@ -345,14 +345,18 @@ class IdToAct(Converter):
 
     def get_gym_dict(self):
         """
-        Transform this converter into a dictionnary that can be used to initialized a gym.spaces.Dict
+        Transform this converter into a dictionary that can be used to initialized a :class:`gym.spaces.Dict`.
+        The converter is modeled as a "Discrete" gym space with as many elements as the number
+        of different actions handled by this converter.
+
+        This is available as the "action" keys of the spaces.Dict gym action space build from it.
 
         This function should not be used "as is", but rather through :class:`grid2op.Converter.GymConverter`
 
         Returns
         -------
         res: :class:`gym.spaces.Dict`
-            The
+            The dict
         """
         # lazy import gym
         from gym import spaces
@@ -399,8 +403,6 @@ class IdToAct(Converter):
         """
         res = gymlike_action["action"]
         if not isinstance(res, (int, dt_int, np.int, np.int64)):
-            import pdb
-            pdb.set_trace()
             raise RuntimeError("TODO")
         return int(res)
 
@@ -443,5 +445,3 @@ class IdToAct(Converter):
         from gym import spaces
         res = spaces.dict.OrderedDict({"action": int(action)})
         return res
-
-

--- a/grid2op/Converter/ToVect.py
+++ b/grid2op/Converter/ToVect.py
@@ -6,7 +6,9 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
+import numpy as np
 from grid2op.Converter.Converters import Converter
+from grid2op.dtypes import dt_float, dt_int
 
 
 class ToVect(Converter):
@@ -17,12 +19,30 @@ class ToVect(Converter):
 
     - `encoded_act` are numpy ndarray
     - `transformed_obs` are numpy ndarray
+    (read more about these concepts by looking at the documentation of :class:`grid2op.Converter.Converters`)
 
+    It is convertible to a gym representation (like the original action space) in the form of a spaces.Box
+    representing a coutinuous action space (even though most component are probably discrete).
+    Note that if converted to a gym space, it is unlikely the method "sample" will yield to valid results.
+    Most of the time it should generate Ambiguous action that will not be handled by grid2op.
+
+    **NB** the conversion to a gym space should be done thanks to the :class:`grid2op.Converter.GymActionSpace`.
     """
     def __init__(self, action_space):
         Converter.__init__(self, action_space)
+        self.init_action_space = action_space
         self.__class__ = ToVect.init_grid(action_space)
         self.do_nothing_vect = action_space({}).to_vect()
+
+        # for gym conversion
+        self.__gym_action_space = None
+        self.__dict_space = None
+        self.__order_gym = None
+        self.__dtypes_gym = None
+        self.__shapes_gym = None
+
+        self.__order_gym_2_me = None
+        self.__order_me_2_gym = None
 
     def convert_obs(self, obs):
         """
@@ -59,5 +79,88 @@ class ToVect(Converter):
 
         """
         res = self.__call__({})
-        res.from_vect(encoded_act)
+        res.from_vect(encoded_act, check_legit=False)
+        return res
+
+    def _init_gym_converter(self):
+        if self.__gym_action_space is None:
+            # lazy import
+            from grid2op.Converter.GymConverter import GymActionSpace
+            from gym import spaces
+            # i do that not to duplicate the code of the low / high bounds
+            gym_action_space = GymActionSpace(self.init_action_space)
+            low = tuple()
+            high = tuple()
+            order_gym = []
+            dtypes = []
+            shapes = []
+            sizes = []
+            prev = 0
+            for k, v in gym_action_space.spaces.items():
+                order_gym.append(k)
+                dtypes.append(v.dtype)
+                if isinstance(v, spaces.MultiBinary):
+                    low += tuple([0 for _ in range(v.n)])
+                    high += tuple([1 for _ in range(v.n)])
+                    my_size = v.n
+                elif isinstance(v, spaces.Box):
+                    low += tuple(v.low)
+                    high += tuple(v.high)
+                    my_size = v.low.shape[0]
+                else:
+                    raise RuntimeError("Impossible to convert this converter to gym. Type {} of data " 
+                                       "encountered while only MultiBinary and Box are supported for now.")
+                shapes.append(my_size)
+                sizes.append(np.arange(my_size) + prev)
+                prev += my_size
+            self.__gym_action_space = gym_action_space
+            my_type = spaces.Box(low=np.array(low),
+                                 high=np.array(high),
+                                 dtype=dt_float)
+
+            order_me = []
+            _order_gym_2_me = np.zeros(my_type.shape[0], dtype=dt_int) - 1
+            _order_me_2_gym = np.zeros(my_type.shape[0], dtype=dt_int) - 1
+            for el in self.init_action_space.attr_list_vect:
+                order_me.append(GymActionSpace.keys_grid2op_2_human[el])
+
+            prev = 0
+            order_gym = list(gym_action_space.spaces.keys())
+            for id_me, nm_attr in enumerate(order_me):
+                id_gym = order_gym.index(nm_attr)
+                index_me = np.arange(shapes[id_gym]) + prev
+                _order_gym_2_me[sizes[id_gym]] = index_me
+                _order_me_2_gym[index_me] = sizes[id_gym]
+                # self.__order_gym_2_me[this_gym_ind] = sizes[id_me]
+                prev += shapes[id_gym]
+            self.__order_gym_2_me = _order_gym_2_me
+            self.__order_me_2_gym = _order_me_2_gym
+            self.__dict_space = {"action": my_type}
+            self.__order_gym = order_gym
+            self.__dtypes_gym = dtypes
+            self.__shapes_gym = shapes
+
+    def get_gym_dict(self):
+        """
+        Convert this action space int a "gym" action space represented by a dictionary (spaces.Dict)
+        This dictionary counts only one keys which is "action" and inside this action is the
+        """
+        self._init_gym_converter()
+        return self.__dict_space
+
+    def convert_action_from_gym(self, gymlike_action):
+        """
+        Convert a gym-like action (ie a Ordered dictionary with one key being only "action") to an
+        action compatible with this converter (in this case a vectorized action).
+        """
+        vect = gymlike_action["action"]
+        return vect[self.__order_gym_2_me]
+
+    def convert_action_to_gym(self, action):
+        """
+        Convert a an action of this converter (ie a numpy array) into an action that is usable with
+        an open ai gym (ie a Ordered dictionary with one key being only "action")
+        """
+        from gym import spaces
+        res = spaces.dict.OrderedDict({"action": action[self.__order_me_2_gym]})
         return res

--- a/grid2op/Converter/__init__.py
+++ b/grid2op/Converter/__init__.py
@@ -11,3 +11,11 @@ from grid2op.Converter.ToVect import ToVect
 from grid2op.Converter.IdToAct import IdToAct
 from grid2op.Converter.AnalogStateConverter import AnalogStateConverter
 from grid2op.Converter.ConnectivityConverter import ConnectivityConverter
+
+try:
+    from grid2op.Converter.GymConverter import GymObservationSpace, GymActionSpace
+    __all__.append("GymObservationSpace")
+    __all__.append("GymActionSpace")
+except ImportError:
+    # you must install open ai gym to benefit from this converter
+    pass

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -902,12 +902,8 @@ class BaseEnv(GridObjects, RandomObject, ABC):
             self._backend_action += action
             action._redispatch[:] = init_disp
 
-            self.env_modification._redispatch[:] = self.actual_dispatch
             self._backend_action += self.env_modification
-
-            # action, for redispatching is composed of multiple actions, so basically i won't check
-            # ramp_min and ramp_max
-            self.env_modification._single_act = False
+            self._backend_action.set_redispatch(self.actual_dispatch)
 
             # now get the new generator voltage setpoint
             voltage_control_act = self._voltage_control(action, prod_v_chronics)

--- a/grid2op/Episode/EpisodeData.py
+++ b/grid2op/Episode/EpisodeData.py
@@ -110,7 +110,8 @@ class EpisodeData:
                                               "observations")
         self.env_actions = CollectionWrapper(env_actions,
                                              helper_action_env,
-                                             "env_actions")
+                                             "env_actions",
+                                             check_legit=False)
         # gives a unique game over for everyone
         # TODO this needs testing!
         action_go = self.actions._game_over
@@ -218,7 +219,7 @@ class EpisodeData:
     def from_disk(cls, agent_path, name=str(1)):
 
         if agent_path is None:
-            raise Grid2OpException("A path to an episode should be provided, please call \"from_disck\" with "
+            raise Grid2OpException("A path to an episode should be provided, please call \"from_disk\" with "
                                    "\"agent_path other\" than None")
         episode_path = os.path.abspath(os.path.join(agent_path, name))
 
@@ -269,7 +270,7 @@ class EpisodeData:
                    observation_space=observation_space,
                    action_space=action_space,
                    helper_action_env=helper_action_env,
-                   path_save=agent_path,
+                   path_save=None, # No save when reading
                    attack=attack,
                    attack_space=attack_space,
                    name=name,
@@ -457,7 +458,7 @@ class CollectionWrapper:
 
     """
 
-    def __init__(self, collection, helper, collection_name):
+    def __init__(self, collection, helper, collection_name, check_legit=True):
         self.collection = collection
         if not hasattr(helper, "from_vect"):
             raise Grid2OpException(f"Object {helper} must implement a "
@@ -470,8 +471,9 @@ class CollectionWrapper:
         self.objects = []
         for i, elem in enumerate(self.collection):
             try:
-                self.objects.append(
-                    self.helper.from_vect(self.collection[i, :]))
+                collection_obj = self.helper.from_vect(self.collection[i, :],
+                                                       check_legit=check_legit)
+                self.objects.append(collection_obj)
             except AmbiguousAction:
                 self._game_over = i
                 break

--- a/grid2op/Episode/EpisodeData.py
+++ b/grid2op/Episode/EpisodeData.py
@@ -131,7 +131,7 @@ class EpisodeData:
             # there is a real game over, i assign the proper value for each collection
             self.actions._game_over = real_go
             self.observations._game_over = real_go + 1
-            self.env_actions._game_over = real_go + 1
+            self.env_actions._game_over = real_go
 
         self.attack = attack
         self.other_rewards = other_rewards

--- a/grid2op/Observation/BaseObservation.py
+++ b/grid2op/Observation/BaseObservation.py
@@ -304,8 +304,6 @@ class BaseObservation(GridObjects):
                   of this next maintenance.
                 - "cooldown_time": for how many timestep i am not supposed to act on the powerline due to cooldown
                   (see :attr:`grid2op.Parameters.Parameters.NB_TIMESTEP_LINE_STATUS_REMODIF` for more information)
-                - "indisponibility": for how many timestep the powerline is unavailable (disconnected, and it's
-                  impossible to reconnect it) due to hazards, maintenance or overflow (incl. cascading failure)
 
             - if a substation is inspected, it returns the topology to this substation in a dictionary with keys:
 
@@ -663,20 +661,20 @@ class BaseObservation(GridObjects):
         """
         if time_step >= len(self._forecasted_inj):
             raise NoForecastAvailable("Forecast for {} timestep ahead is not possible with your chronics.".format(time_step))
-        a = self._forecasted_grid_act[time_step]["inj_action"]
+        t, a = self._forecasted_inj[time_step]
         prod_p_f = np.full(self.n_gen, fill_value=np.NaN, dtype=dt_float)
         prod_v_f = np.full(self.n_gen, fill_value=np.NaN, dtype=dt_float)
         load_p_f = np.full(self.n_load, fill_value=np.NaN, dtype=dt_float)
         load_q_f = np.full(self.n_load, fill_value=np.NaN, dtype=dt_float)
 
-        if "prod_p" in a._dict_inj:
-            prod_p_f = a._dict_inj["prod_p"]
-        if "prod_v" in a._dict_inj:
-            prod_v_f = a._dict_inj["prod_v"]
-        if "load_p" in a._dict_inj:
-            load_p_f = a._dict_inj["load_p"]
-        if "load_q" in a._dict_inj:
-            load_q_f = a._dict_inj["load_q"]
+        if "prod_p" in a["injection"]:
+            prod_p_f = a["injection"]["prod_p"]
+        if "prod_v" in a["injection"]:
+            prod_v_f = a["injection"]["prod_v"]
+        if "load_p" in a["injection"]:
+            load_p_f = a["injection"]["load_p"]
+        if "load_q" in a["injection"]:
+            load_q_f = a["injection"]["load_q"]
         tmp_arg = ~np.isfinite(prod_p_f)
         prod_p_f[tmp_arg] = self.prod_p[tmp_arg]
         tmp_arg = ~np.isfinite(prod_v_f)

--- a/grid2op/Observation/CompleteObservation.py
+++ b/grid2op/Observation/CompleteObservation.py
@@ -179,7 +179,7 @@ class CompleteObservation(BaseObservation):
         self.target_dispatch[:] = env.target_dispatch
         self.actual_dispatch[:] = env.actual_dispatch
 
-    def from_vect(self, vect):
+    def from_vect(self, vect, check_legit=True):
         """
         Convert back an observation represented as a vector into a proper observation.
 
@@ -196,7 +196,7 @@ class CompleteObservation(BaseObservation):
         # reset the matrices
         self._reset_matrices()
         # and ensure everything is reloaded properly
-        super().from_vect(vect)
+        super().from_vect(vect, check_legit=check_legit)
 
     def to_dict(self):
         """

--- a/grid2op/Observation/CompleteObservation.py
+++ b/grid2op/Observation/CompleteObservation.py
@@ -142,9 +142,9 @@ class CompleteObservation(BaseObservation):
         self.day_of_week = dt_int(env.time_stamp.weekday())
 
         # get the values related to topology
-        self.timestep_overflow = copy.copy(env.timestep_overflow)
-        self.line_status = copy.copy(env.backend.get_line_status())
-        self.topo_vect = copy.copy(env.backend.get_topo_vect())
+        self.timestep_overflow[:] = env.timestep_overflow
+        self.line_status[:] = env.backend.get_line_status()
+        self.topo_vect[:] = env.backend.get_topo_vect()
 
         # get the values related to continuous values
         self.prod_p[:], self.prod_q[:], self.prod_v[:] = env.backend.generators_info()
@@ -167,7 +167,7 @@ class CompleteObservation(BaseObservation):
             self._forecasted_inj += env.chronics_handler.forecasts()
             self._forecasted_grid = [None for _ in self._forecasted_inj]
 
-        self.rho = env.backend.get_relative_flow().astype(dt_float)
+        self.rho[:] = env.backend.get_relative_flow().astype(dt_float)
 
         # cool down and reconnection time after hard overflow, soft overflow or cascading failure
         self.time_before_cooldown_line[:] = env.times_before_line_status_actionable

--- a/grid2op/Observation/ObservationSpace.py
+++ b/grid2op/Observation/ObservationSpace.py
@@ -130,3 +130,7 @@ class ObservationSpace(SerializableObservationSpace):
         :return:
         """
         return self.n
+
+    def get_empty_observation(self):
+        """return an empty observation, for internal use only."""
+        return copy.deepcopy(self._empty_obs)

--- a/grid2op/Space/GridObjects.py
+++ b/grid2op/Space/GridObjects.py
@@ -564,7 +564,7 @@ class GridObjects:
     def check_space_legit(self):
         pass
 
-    def from_vect(self, vect):
+    def from_vect(self, vect, check_legit=True):
         """
         Convert a GridObjects, represented as a vector, into an GridObjects object.
 
@@ -602,7 +602,9 @@ class GridObjects:
             tmp = vect[prev_:(prev_ + sh)].astype(dt)
             self._assign_attr_from_name(attr_nm, tmp)
             prev_ += sh
-        self.check_space_legit()
+
+        if check_legit:
+            self.check_space_legit()
 
     def size(self):
         """

--- a/grid2op/Space/SerializableSpace.py
+++ b/grid2op/Space/SerializableSpace.py
@@ -193,7 +193,7 @@ class SerializableSpace(GridObjects, RandomObject):
         """
         return self.n
 
-    def from_vect(self, obj_as_vect):
+    def from_vect(self, obj_as_vect, check_legit=True):
         """
         Convert an action, represented as a vector to a valid :class:`BaseAction` instance
 
@@ -211,7 +211,7 @@ class SerializableSpace(GridObjects, RandomObject):
 
         """
         res = copy.deepcopy(self._template_obj)
-        res.from_vect(obj_as_vect)
+        res.from_vect(obj_as_vect, check_legit=check_legit)
         return res
 
     def extract_from_vect(self, obj_as_vect, attr_name):

--- a/grid2op/Space/SerializableSpace.py
+++ b/grid2op/Space/SerializableSpace.py
@@ -83,6 +83,7 @@ class SerializableSpace(GridObjects, RandomObject):
 
         self.shape = self._template_obj.shape()
         self.dtype = self._template_obj.dtype()
+        self.attr_list_vect = self._template_obj.attr_list_vect
 
         self._to_extract_vect = {}  # key: attr name, value: tuple: (beg_, end_, dtype)
         beg_ = 0

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -1442,3 +1442,85 @@ class BaseTestChangeBusSlack(MakeBackend):
         p_subs, q_subs, p_bus, q_bus = env.backend.check_kirchoff()
         assert np.all(np.abs(p_subs) <= self.tol_one)
         assert np.all(np.abs(p_bus) <= self.tol_one)
+
+
+class BaseIssuesTest(MakeBackend):
+    def test_issue_125(self):
+        # https://github.com/rte-france/Grid2Op/issues/125
+        self.skip_if_needed()
+        backend = self.make_backend()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = grid2op.make("rte_case14_realistic", test=True,
+                               backend=backend)
+        action = env.action_space({"set_bus": {"loads_id": [(1, -1)]}})
+        obs, reward, am_i_done, info = env.step(action)
+        assert info["is_illegal"] is False
+        assert info["is_ambiguous"] is False
+        assert len(info["exception"])
+        assert am_i_done
+
+        env.reset()
+        action = env.action_space({"set_bus": {"generators_id": [(1, -1)]}})
+        obs, reward, am_i_done, info = env.step(action)
+        assert info["is_illegal"] is False
+        assert info["is_ambiguous"] is False
+        assert len(info["exception"])
+        assert am_i_done
+
+    def test_issue_134(self):
+        self.skip_if_needed()
+        backend = self.make_backend()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = grid2op.make("rte_case14_realistic", test=True,
+                               backend=backend)
+        LINE_ID = 2
+
+        # Disconnect ex
+        action = env.action_space({
+            'set_bus': {
+                "lines_or_id": [(LINE_ID, 0)],
+                "lines_ex_id": [(LINE_ID, -1)],
+            }
+        })
+        obs, reward, done, info = env.step(action)
+        assert obs.line_status[LINE_ID] == False
+        assert obs.topo_vect[obs.line_or_pos_topo_vect[LINE_ID]] == -1
+        assert obs.topo_vect[obs.line_ex_pos_topo_vect[LINE_ID]] == -1
+        
+        # Reconnect ex on bus 2
+        action = env.action_space({
+            'set_bus': {
+                "lines_or_id": [(LINE_ID, 0)],
+            "lines_ex_id": [(LINE_ID, 2)],
+            }
+        })
+        obs, reward, done, info = env.step(action)
+        assert obs.line_status[LINE_ID] == True
+        assert obs.topo_vect[obs.line_or_pos_topo_vect[LINE_ID]] == 1
+        assert obs.topo_vect[obs.line_ex_pos_topo_vect[LINE_ID]] == 2
+    
+        # Disconnect or
+        action = env.action_space({
+            'set_bus': {
+                "lines_or_id": [(LINE_ID, -1)],
+                "lines_ex_id": [(LINE_ID, 0)],
+            }
+        })
+        obs, reward, done, info = env.step(action)
+        assert obs.line_status[LINE_ID] == False
+        assert obs.topo_vect[obs.line_or_pos_topo_vect[LINE_ID]] == -1
+        assert obs.topo_vect[obs.line_ex_pos_topo_vect[LINE_ID]] == -1
+
+        # Reconnect or on bus 1
+        action = env.action_space({
+            'set_bus': {
+                "lines_or_id": [(LINE_ID, 1)],
+                "lines_ex_id": [(LINE_ID, 0)],
+            }
+        })
+        obs, reward, done, info = env.step(action)
+        assert obs.line_status[LINE_ID] == True
+        assert obs.topo_vect[obs.line_or_pos_topo_vect[LINE_ID]] == 1
+        assert obs.topo_vect[obs.line_ex_pos_topo_vect[LINE_ID]] == 2

--- a/grid2op/tests/__init__.py
+++ b/grid2op/tests/__init__.py
@@ -6,5 +6,8 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
-__all__ = ["BaseBackendTest",
-           "BaseRedispTest"]
+__all__ = [
+    "BaseBackendTest",
+    "BaseIssuesTest",
+    "BaseRedispTest"
+]

--- a/grid2op/tests/issue_126.py
+++ b/grid2op/tests/issue_126.py
@@ -1,0 +1,45 @@
+import unittest
+import warnings
+import grid2op
+from grid2op.Agent import DeltaRedispatchRandomAgent
+from grid2op.Runner import Runner
+from grid2op import make
+from grid2op.Episode import EpisodeData
+import os
+import numpy as np
+import tempfile
+
+class Issue126Tester(unittest.TestCase):
+
+  def test_issue_126(self):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+      #run redispatch agent on one scenario for 100 timesteps
+      dataset = "rte_case14_realistic"
+      nb_episode=1
+      nb_timesteps=100
+
+      with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        env = make(dataset)
+        agent = DeltaRedispatchRandomAgent(env.action_space)
+        runner = Runner(**env.get_params_for_runner(),
+                        agentClass=None,
+                        agentInstance=agent)
+        nb_episode=1
+        res = runner.run(nb_episode=nb_episode,
+                         path_save=tmpdirname,
+                         nb_process=1,
+                         max_iter=nb_timesteps,
+                         env_seeds=[0],
+                         agent_seeds=[0],
+                         pbar=False)
+
+        episode_data = EpisodeData.from_disk(tmpdirname, '000')
+
+        assert len(episode_data.actions.objects) == nb_timesteps
+        assert len(episode_data.observations.objects) == (nb_timesteps + 1)
+        assert len(episode_data.actions) == nb_timesteps
+        assert len(episode_data.observations) == (nb_timesteps + 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grid2op/tests/issue_131.py
+++ b/grid2op/tests/issue_131.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import grid2op
+import unittest
+import numpy as np
+
+class Issue131Tester(unittest.TestCase):
+
+    def test_issue_131(self):
+        env = grid2op.make("rte_case14_realistic")
+
+        # Get forecast after a simulate works
+        obs = env.reset()
+        obs.simulate(env.action_space({}))
+        prod_p_fa, prod_v_fa, load_p_fa, load_q_fa = obs.get_forecasted_inj()
+        shapes_a = (prod_p_fa.shape, prod_v_fa.shape,
+                    load_p_fa.shape, load_q_fa.shape)
+
+        # Get forecast before any simulate doesnt work
+        env.set_id(1)
+        obs = env.reset()
+        prod_p_fb, prod_v_fb, load_p_fb, load_q_fb = obs.get_forecasted_inj()
+        shapes_b = (prod_p_fb.shape, prod_v_fb.shape,
+                    load_p_fb.shape, load_q_fb.shape)
+
+        assert shapes_a == shapes_b
+        assert np.all(prod_p_fa == prod_p_fb)
+        assert np.all(prod_v_fa == prod_v_fb)
+        assert np.all(load_p_fa == load_p_fb)
+        assert np.all(load_q_fa == load_q_fb)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grid2op/tests/test_Action.py
+++ b/grid2op/tests/test_Action.py
@@ -48,9 +48,13 @@ class TestActionBase(ABC):
 
         self.n_line = 20
         GridObjects.env_name = "test_action_env"
+        GridObjects.n_gen = 5
         GridObjects.name_gen = ["gen_{}".format(i) for i in range(5)]
+        GridObjects.n_load = 11
         GridObjects.name_load = ["load_{}".format(i) for i in range(11)]
+        GridObjects.n_line = self.n_line
         GridObjects.name_line = ["line_{}".format(i) for i in range(self.n_line)]
+        GridObjects.n_sub = 14
         GridObjects.name_sub = ["sub_{}".format(i) for i in range(14)]
         GridObjects.sub_info = np.array([3, 6, 4, 6, 5, 6, 3, 2, 5, 3, 3, 3, 4, 3], dtype=dt_int)
         GridObjects.load_to_subid = np.array([1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13])
@@ -71,41 +75,79 @@ class TestActionBase(ABC):
                                           31, 32, 37, 38, 40, 46, 50])
         GridObjects.line_ex_pos_topo_vect = np.array([3, 19, 9, 13, 20, 14, 21, 30, 35, 24, 45, 48, 52,
                                           33, 36, 42, 55, 43, 49, 53])
+
+        GridObjects.redispatching_unit_commitment_availble = True
+        GridObjects.gen_type = np.array(["thermal"] * 5)
+        GridObjects.gen_pmin = np.array([0.0] * 5)
+        GridObjects.gen_pmax = np.array([100.0] * 5)
+        GridObjects.gen_min_uptime = np.array([0] * 5)
+        GridObjects.gen_min_downtime = np.array([0] * 5)
+        GridObjects.gen_cost_per_MW = np.array([70.0] * 5)
+        GridObjects.gen_startup_cost = np.array([0.0] * 5)
+        GridObjects.gen_shutdown_cost = np.array([0.0] * 5)
+        GridObjects.gen_redispatchable = np.array([True, False, False, True, False])
+        GridObjects.gen_max_ramp_up = np.array([10., 5., 15., 7., 8.])
+        GridObjects.gen_max_ramp_down = np.array([11., 6., 16., 8., 9.])
+
         self.gridobj = GridObjects()
 
-        self.res = {'name_gen': ['gen_0', 'gen_1', 'gen_2', 'gen_3', 'gen_4'],
-                    'name_load': ['load_0', 'load_1', 'load_2', 'load_3', 'load_4', 'load_5', 'load_6',
-                                  'load_7', 'load_8', 'load_9', 'load_10'],
-                    'name_line': ['line_0', 'line_1', 'line_2', 'line_3', 'line_4', 'line_5', 'line_6', 'line_7',
-                                  'line_8', 'line_9', 'line_10', 'line_11', 'line_12', 'line_13', 'line_14',
-                                  'line_15', 'line_16', 'line_17', 'line_18', 'line_19'],
-                    'name_sub': ['sub_0', 'sub_1', 'sub_2', 'sub_3', 'sub_4', 'sub_5', 'sub_6', 'sub_7', 'sub_8',
-                                 'sub_9', 'sub_10', 'sub_11', 'sub_12', 'sub_13'],
-                    'sub_info': [3, 6, 4, 6, 5, 6, 3, 2, 5, 3, 3, 3, 4, 3],
-                    'load_to_subid': [1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13],
-                    'gen_to_subid': [0, 1, 2, 5, 7],
-                    'line_or_to_subid': [0, 0, 1, 1, 1, 2, 3, 3, 3, 4, 5, 5, 5, 6, 6, 8, 8, 9, 11, 12],
-                    'line_ex_to_subid': [1, 4, 2, 3, 4, 3, 4, 6, 8, 5, 10, 11, 12, 7, 8, 9, 13, 10, 12, 13],
-                    'load_to_sub_pos': [4, 2, 5, 4, 4, 4, 1, 1, 1, 2, 1],
-                    'gen_to_sub_pos': [2, 5, 3, 5, 1],
-                    'line_or_to_sub_pos': [0, 1, 1, 2, 3, 1, 2, 3, 4, 3, 1, 2, 3, 1, 2, 2, 3, 0, 0, 1],
-                    'line_ex_to_sub_pos': [0, 0, 0, 0, 1, 1, 2, 0, 0, 0, 2, 2, 3, 0, 1, 2, 2, 0, 0, 0],
-                    'load_pos_topo_vect': [7, 11, 18, 23, 28, 39, 41, 44, 47, 51, 54],
-                    'gen_pos_topo_vect': [2, 8, 12, 29, 34],
-                    'line_or_pos_topo_vect': [0, 1, 4, 5, 6, 10, 15, 16, 17, 22, 25, 26, 27, 31, 32, 37, 38, 40, 46, 50],
-                    'line_ex_pos_topo_vect': [3, 19, 9, 13, 20, 14, 21, 30, 35, 24, 45, 48, 52, 33, 36, 42, 55, 43, 49, 53],
-                    'gen_type': None, 'gen_pmin': None, 'gen_pmax': None, 'gen_redispatchable': None,
-                    'gen_max_ramp_up': None, 'gen_max_ramp_down': None, 'gen_min_uptime': None, 'gen_min_downtime': None,
-                    'gen_cost_per_MW': None, 'gen_startup_cost': None, 'gen_shutdown_cost': None,
-                    "grid_layout": None,
-                    "shunt_to_subid": None,
-                    "name_shunt": None
-                    }
+        self.res = {
+            'name_gen': ['gen_0', 'gen_1', 'gen_2', 'gen_3', 'gen_4'],
+            'name_load': ['load_0', 'load_1', 'load_2',
+                          'load_3', 'load_4', 'load_5', 'load_6',
+                          'load_7', 'load_8', 'load_9', 'load_10'],
+            'name_line': ['line_0', 'line_1', 'line_2',
+                          'line_3', 'line_4', 'line_5', 'line_6', 'line_7',
+                          'line_8', 'line_9', 'line_10', 'line_11',
+                          'line_12', 'line_13', 'line_14',
+                          'line_15', 'line_16', 'line_17',
+                          'line_18', 'line_19'],
+            'name_sub': ['sub_0', 'sub_1', 'sub_2', 'sub_3',
+                         'sub_4', 'sub_5', 'sub_6', 'sub_7', 'sub_8',
+                         'sub_9', 'sub_10', 'sub_11', 'sub_12', 'sub_13'],
+            'sub_info': [3, 6, 4, 6, 5, 6, 3, 2, 5, 3, 3, 3, 4, 3],
+            'load_to_subid': [1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13],
+            'gen_to_subid': [0, 1, 2, 5, 7],
+            'line_or_to_subid': [0, 0, 1, 1, 1, 2, 3, 3,
+                                 3, 4, 5, 5, 5, 6, 6, 8, 8, 9, 11, 12],
+            'line_ex_to_subid': [1, 4, 2, 3, 4, 3, 4, 6,
+                                 8, 5, 10, 11, 12, 7, 8, 9, 13, 10, 12, 13],
+            'load_to_sub_pos': [4, 2, 5, 4, 4, 4, 1, 1, 1, 2, 1],
+            'gen_to_sub_pos': [2, 5, 3, 5, 1],
+            'line_or_to_sub_pos': [0, 1, 1, 2, 3, 1, 2,
+                                   3, 4, 3, 1, 2, 3, 1, 2, 2, 3, 0, 0, 1],
+            'line_ex_to_sub_pos': [0, 0, 0, 0, 1, 1, 2,
+                                   0, 0, 0, 2, 2, 3, 0, 1, 2, 2, 0, 0, 0],
+            'load_pos_topo_vect': [7, 11, 18, 23, 28,
+                                   39, 41, 44, 47, 51, 54],
+            'gen_pos_topo_vect': [2, 8, 12, 29, 34],
+            'line_or_pos_topo_vect': [0, 1, 4, 5, 6, 10,
+                                      15, 16, 17, 22, 25, 26,
+                                      27, 31, 32, 37, 38, 40, 46, 50],
+            'line_ex_pos_topo_vect': [3, 19, 9, 13, 20,
+                                      14, 21, 30, 35, 24, 45,
+                                      48, 52, 33, 36, 42, 55, 43, 49, 53],
+            'gen_type': ["thermal"] * 5,
+            'gen_pmin': [0.0] * 5,
+            'gen_pmax': [100.0] * 5,
+            'gen_redispatchable': [True, False, False, True, False],
+            'gen_max_ramp_up': [10., 5., 15., 7., 8.],
+            'gen_max_ramp_down': [11., 6., 16., 8., 9.],
+            'gen_min_uptime': [0] * 5,
+            'gen_min_downtime': [0] * 5,
+            'gen_cost_per_MW': [70.0] * 5,
+            'gen_startup_cost': [0.0] * 5,
+            'gen_shutdown_cost': [0.0] * 5,
+            "grid_layout": None,
+            "shunt_to_subid": None,
+            "name_shunt": None
+        }
 
         # self.size_act = 229
         self.ActionSpaceClass = ActionSpace.init_grid(self.gridobj)
         # self.helper_action = ActionSpace(self.gridobj, legal_action=self.game_rules.legal_action)
         self.helper_action = self._action_setup()
+        self.helper_action.seed(42)
         # save_to_dict(self.res, self.helper_action, "subtype", lambda x: re.sub("(<class ')|('>)", "", "{}".format(x)))
         save_to_dict(self.res, self.helper_action,
                      "_init_subtype",
@@ -771,6 +813,13 @@ class TestActionBase(ABC):
         vect = act.to_vect()
         res = self.helper_action.extract_from_vect(vect, "_set_line_status")
         assert np.all(res == act._set_line_status)
+
+    def test_sample(self):
+        try:
+            for i in range(10):
+                act = self.helper_action.sample()
+        except:
+            assert False, "sample() raised"
 
 
 class TestAction(TestActionBase, unittest.TestCase):

--- a/grid2op/tests/test_GymConverter.py
+++ b/grid2op/tests/test_GymConverter.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+# TODO test the json part but... https://github.com/openai/gym-http-api/issues/62 or https://github.com/openai/gym/issues/1841
+import tempfile
+import json
+import tempfile
+import json
+import warnings
+from grid2op.dtypes import dt_float, dt_bool, dt_int
+from grid2op.tests.helper_path_test import *
+from grid2op.MakeEnv import make
+from grid2op.Converter import GymActionSpace, GymObservationSpace
+
+import pdb
+
+
+class TestWithoutConverter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tol = 1e-6
+
+    def test_creation(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                # test i can create
+                obs_space = GymObservationSpace(env)
+                act_space = GymActionSpace(env.action_space)
+
+    def _aux_test_json(self, space, obj=None):
+        if obj is None:
+            obj = space.sample()
+        obj_json = space.to_jsonable([obj])
+        # test save to json
+        with tempfile.TemporaryFile(mode="w") as f:
+            json.dump(obj_json, fp=f)
+
+        # test read from json
+        obj2 = space.from_jsonable(obj_json)[0]
+
+        # test they are equal
+        for k, v in obj2.items():
+            assert k in obj
+            tmp = obj[k]
+            if isinstance(tmp, (int, float, dt_float, dt_int, dt_bool)):
+                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
+            elif len(tmp) == 1:
+                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
+            else:
+                assert np.all(np.abs(obj[k].astype(dt_float) - obj2[k].astype(dt_float)) <= self.tol)
+        for k, v in obj.items():
+            assert k in obj2  # make sure every keys of obj are in obj2
+
+    def test_json(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                # test i can create
+                obs_space = GymObservationSpace(env)
+                act_space = GymActionSpace(env.action_space)
+
+                obs_space.seed(0)
+                act_space.seed(0)
+
+                self._aux_test_json(obs_space)
+                self._aux_test_json(act_space)
+
+    def test_to_from_gym_obs(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                obs_space = GymObservationSpace(env)
+
+                obs = env.reset()
+                gym_obs = obs_space.to_gym(obs)
+                self._aux_test_json(obs_space, gym_obs)
+                assert obs_space.contains(gym_obs)
+                obs2 = obs_space.from_gym(gym_obs)
+                assert obs == obs2
+
+                for i in range(10):
+                    obs, *_ = env.step(env.action_space())
+                    gym_obs = obs_space.to_gym(obs)
+                    self._aux_test_json(obs_space, gym_obs)
+                    assert obs_space.contains(gym_obs), "gym space does not contain the observation for ts {}".format(i)
+                    obs2 = obs_space.from_gym(gym_obs)
+                    assert obs == obs2, "obs and converted obs are not equal for ts {}".format(i)
+
+    def test_to_from_gym_act(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                act_space = GymActionSpace(env.action_space)
+
+                act = env.action_space()
+                gym_act = act_space.to_gym(act)
+                self._aux_test_json(act_space, gym_act)
+                assert act_space.contains(gym_act)
+                act2 = act_space.from_gym(gym_act)
+                assert act == act2
+
+                act_space.seed(0)
+                for i in range(10):
+                    gym_act = act_space.sample()
+                    act = act_space.from_gym(gym_act)
+                    self._aux_test_json(act_space, gym_act)
+                    gym_act2 = act_space.to_gym(act)
+                    act2 = act_space.from_gym(gym_act2)
+                    assert act == act2

--- a/grid2op/tests/test_GymConverter.py
+++ b/grid2op/tests/test_GymConverter.py
@@ -20,17 +20,9 @@ from grid2op.Converter import GymActionSpace, GymObservationSpace, IdToAct
 import pdb
 
 
-class TestWithoutConverter(unittest.TestCase):
-    def setUp(self) -> None:
+class BaseTestGymConverter:
+    def __init__(self):
         self.tol = 1e-6
-
-    def test_creation(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            with make("l2rpn_wcci_2020", test=True) as env:
-                # test i can create
-                obs_space = GymObservationSpace(env)
-                act_space = GymActionSpace(env.action_space)
 
     def _aux_test_json(self, space, obj=None):
         if obj is None:
@@ -55,6 +47,19 @@ class TestWithoutConverter(unittest.TestCase):
                 assert np.all(np.abs(obj[k].astype(dt_float) - obj2[k].astype(dt_float)) <= self.tol)
         for k, v in obj.items():
             assert k in obj2  # make sure every keys of obj are in obj2
+
+
+class TestWithoutConverter(unittest.TestCase, BaseTestGymConverter):
+    def setUp(self) -> None:
+        BaseTestGymConverter.__init__(self)
+
+    def test_creation(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            with make("l2rpn_wcci_2020", test=True) as env:
+                # test i can create
+                obs_space = GymObservationSpace(env)
+                act_space = GymActionSpace(env.action_space)
 
     def test_json(self):
         with warnings.catch_warnings():
@@ -114,10 +119,10 @@ class TestWithoutConverter(unittest.TestCase):
                     assert act == act2
 
 
-class TestIdToAct(unittest.TestCase):
+class TestIdToAct(unittest.TestCase, BaseTestGymConverter):
     def setUp(self) -> None:
-        self.tol = 1e-6
-
+        BaseTestGymConverter.__init__(self)
+        
     def test_creation(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
@@ -125,30 +130,7 @@ class TestIdToAct(unittest.TestCase):
                 # test i can create
                 idtoact = IdToAct(env.action_space)
                 act_space = GymActionSpace(idtoact)
-
-    def _aux_test_json(self, space, obj=None):
-        if obj is None:
-            obj = space.sample()
-        obj_json = space.to_jsonable([obj])
-        # test save to json
-        with tempfile.TemporaryFile(mode="w") as f:
-            json.dump(obj_json, fp=f)
-
-        # test read from json
-        obj2 = space.from_jsonable(obj_json)[0]
-
-        # test they are equal
-        for k, v in obj2.items():
-            assert k in obj
-            tmp = obj[k]
-            if isinstance(tmp, (int, float, dt_float, dt_int, dt_bool)):
-                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
-            elif len(tmp) == 1:
-                assert np.all(np.abs(float(obj[k]) - float(obj2[k])) <= self.tol)
-            else:
-                assert np.all(np.abs(obj[k].astype(dt_float) - obj2[k].astype(dt_float)) <= self.tol)
-        for k, v in obj.items():
-            assert k in obj2  # make sure every keys of obj are in obj2
+                act_space.sample()
 
     def test_json(self):
         with warnings.catch_warnings():

--- a/grid2op/tests/test_PandaPowerBackend.py
+++ b/grid2op/tests/test_PandaPowerBackend.py
@@ -16,10 +16,17 @@ from grid2op.tests.helper_path_test import PATH_DATA_TEST_PP, PATH_DATA_TEST
 from grid2op.Backend import PandaPowerBackend
 
 from grid2op.tests.helper_path_test import HelperTests
-from grid2op.tests.BaseBackendTest import BaseTestNames, BaseTestLoadingCase, BaseTestLoadingBackendFunc
-from grid2op.tests.BaseBackendTest import BaseTestTopoAction, BaseTestEnvPerformsCorrectCascadingFailures
-from grid2op.tests.BaseBackendTest import BaseTestChangeBusAffectRightBus, BaseTestShuntAction
-from grid2op.tests.BaseBackendTest import BaseTestResetEqualsLoadGrid, BaseTestVoltageOWhenDisco, BaseTestChangeBusSlack
+from grid2op.tests.BaseBackendTest import BaseTestNames
+from grid2op.tests.BaseBackendTest import BaseTestLoadingCase
+from grid2op.tests.BaseBackendTest import BaseTestLoadingBackendFunc
+from grid2op.tests.BaseBackendTest import BaseTestTopoAction
+from grid2op.tests.BaseBackendTest import BaseTestEnvPerformsCorrectCascadingFailures
+from grid2op.tests.BaseBackendTest import BaseTestChangeBusAffectRightBus
+from grid2op.tests.BaseBackendTest import BaseTestShuntAction
+from grid2op.tests.BaseBackendTest import BaseTestResetEqualsLoadGrid
+from grid2op.tests.BaseBackendTest import BaseTestVoltageOWhenDisco
+from grid2op.tests.BaseBackendTest import BaseTestChangeBusSlack
+from grid2op.tests.BaseBackendTest import BaseIssuesTest
 PATH_DATA_TEST_INIT = PATH_DATA_TEST
 PATH_DATA_TEST = PATH_DATA_TEST_PP
 
@@ -126,6 +133,11 @@ class TestChangeBusSlack(HelperTests, BaseTestChangeBusSlack):
         return PandaPowerBackend(detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures)
 
 
+class TestIssuesTest(HelperTests, BaseIssuesTest):
+    def make_backend(self, detailed_infos_for_cascading_failures=False):
+        return PandaPowerBackend(detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures)
+
+
 # Specific to pandapower power
 class TestChangeBusAffectRightBus2(unittest.TestCase):
     def skip_if_needed(self):
@@ -179,6 +191,7 @@ class TestChangeBusAffectRightBus2(unittest.TestCase):
         assert np.all(np.isfinite(obs.v_or))
         assert np.sum(env.backend._grid["bus"]["in_service"]) == 14
         assert env.backend._grid["trafo"]["hv_bus"][2] == 4
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ pkgs = {
             "seaborn>=0.10.0",
             "imageio>=2.8.0",
             "pygifsicle>=1.0.1",
-            "psutil>=5.7.0"
+            "psutil>=5.7.0",
+            "gym>=0.17.1",
         ],
         "challenge": [
             "numpy==1.18.3",


### PR DESCRIPTION
Improve on issue #16 

The following improvements are made:
- standard observation space is convertible to a spaces.Dict (keys: the attributes name of the observation, values: the corresponding attribute value in a form of a spaces.Discrete, spaces.Box or spaces.MultiBinary depending on the attribute)
-  standard observation space is convertible to a spaces.Dict (keys: the attributes name of the action, values: the corresponding attribute value in a form of a spaces.Discrete, spaces.Box or spaces.MultiBinary depending on the attribute)
- IdToAct converter is convertible into a gym spaces.Dict (with key "action" of type  spaces.Discrete)
- ToVect converter is convertible into a gym spaces.Dict (with key "action" of type spaces.Box)