### PR TITLE
Fix substation and powerline IDs in illegal action exception

### DIFF
--- a/grid2op/Rules/PreventReconnection.py
+++ b/grid2op/Rules/PreventReconnection.py
@@ -39,12 +39,12 @@ class PreventReconnection(BaseRules):
         if np.any(env.times_before_line_status_actionable[aff_lines] > 0):
             # i tried to act on a powerline too shortly after a previous action
             # or shut down due to an overflow or opponent or hazards or maintenance
-            ids = np.where(env.times_before_line_status_actionable[aff_lines] > 0)[0]
+            ids = np.logical_and(env.times_before_line_status_actionable[aff_lines] > 0, aff_lines).nonzero()[0]
             return False, IllegalAction("Powerline with ids {} have been modified illegally (cooldown)".format(ids))
 
         if np.any(env.times_before_topology_actionable[aff_subs] > 0):
             # I tried to act on a topology too shortly after a previous action
-            ids = np.where(env.times_before_line_status_actionable[aff_lines] > 0)[0]
+            ids = np.logical_and(env.times_before_topology_actionable[aff_subs] > 0, aff_subs).nonzero()[0]
             return False, IllegalAction("Substation with ids {} have been modified illegally (cooldown)".format(ids))
 
         return True, None


### PR DESCRIPTION
The IDs of the substation and powerlines were being determined as the index of the already index reduced array, so they were not correct. Also the topology check was using the line status array. The IDs are now correct.