### PR TITLE
Few bug fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,18 @@ Change Log
 - [???] "asynch" multienv
 - [???] properly model interconnecting powerlines
 
+[1.6.6] - 2022-xx-yy
+---------------------
+- [BREAKING] in the "gym_compat" module the curtailment action type has 
+  for dimension the number of dispatchable generators (as opposed to all generators
+  before) this was mandatory to fix issue https://github.com/rte-france/Grid2Op/issues/282
+- [BREAKING] the size of the continuous action space for the redispatching in
+  case of gym compatibility has also been adjusted to be consistent with curtailment.
+  Before it has the size of `env.n_gen` now `np.sum(env.gen_redispatchable)`.
+- [FIXED] a bug in the gym action space: see issue https://github.com/rte-france/Grid2Op/issues/281
+- [FIXED] a bug in the gym box action space: see issue https://github.com/rte-france/Grid2Op/issues/283
+- [IMPROVED] better difference between env_path and grid_path in environments.
+
 [1.6.5] - 2022-01-19
 ---------------------
 - [BREAKING] the function "env.reset()" now reset the underlying pseudo random number generators

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -217,6 +217,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
     ALARM_FILE_NAME = "alerts_info.json"
 
     def __init__(self,
+                 init_env_path,
                  init_grid_path,
                  parameters,
                  voltagecontrolerClass,
@@ -441,6 +442,11 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         else:
             self._kwargs_observation = {}
 
+        if init_env_path is not None:
+            self._init_env_path = os.path.abspath(init_env_path)
+        else:
+            self._init_env_path = None
+
     def _custom_deepcopy_for_copy(self, new_obj, dict_=None):
         if self.__closed:
             raise RuntimeError("Impossible to make a copy of a closed environment !")
@@ -450,6 +456,8 @@ class BaseEnv(GridObjects, RandomObject, ABC):
             dict_ = {}
 
         new_obj._init_grid_path = copy.deepcopy(self._init_grid_path)
+        new_obj._init_env_path = copy.deepcopy(self._init_env_path)
+        
         new_obj._DEBUG = self._DEBUG
         new_obj._parameters = copy.deepcopy(self._parameters)
         new_obj.with_forecast = self.with_forecast
@@ -644,7 +652,9 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         """
         if self.__closed:
             raise EnvError("This environment is closed, you cannot get its path.")
-        return os.path.split(self._init_grid_path)[0]
+        # return os.path.split(self._init_grid_path)[0]
+        res = self._init_env_path if self._init_env_path is not None else ""
+        return res
 
     def load_alarm_data(self):
         """
@@ -2759,5 +2769,5 @@ class BaseEnv(GridObjects, RandomObject, ABC):
 
     def __del__(self):
         """when the environment is garbage collected, free all the memory, including cross reference to itself in the observation space."""
-        if not self.__closed:
+        if hasattr(self, "_BaseEnv__closed") and not self.__closed:
             self.close()

--- a/grid2op/Environment/Environment.py
+++ b/grid2op/Environment/Environment.py
@@ -61,6 +61,7 @@ class Environment(BaseEnv):
     REGEX_SPLIT = r"^[a-zA-Z0-9]*$"
 
     def __init__(self,
+                 init_env_path: str,
                  init_grid_path: str,
                  chronics_handler,
                  backend,
@@ -96,6 +97,7 @@ class Environment(BaseEnv):
                  _is_test=False
                  ):
         BaseEnv.__init__(self,
+                         init_env_path=init_env_path,
                          init_grid_path=init_grid_path,
                          parameters=parameters,
                          thermal_limit_a=thermal_limit_a,
@@ -902,6 +904,7 @@ class Environment(BaseEnv):
 
         """
         res = {}
+        res["init_env_path"] = self._init_env_path
         res["init_grid_path"] = self._init_grid_path
         res["chronics_handler"] = copy.deepcopy(self.chronics_handler)
         if with_backend:
@@ -1448,6 +1451,7 @@ class Environment(BaseEnv):
 
         """
         res = {}
+        res["init_env_path"] = self._init_env_path
         res["init_grid_path"] = self._init_grid_path
         res["path_chron"] = self.chronics_handler.path
         res["parameters_path"] = self._parameters.to_dict()

--- a/grid2op/MakeEnv/MakeFromPath.py
+++ b/grid2op/MakeEnv/MakeFromPath.py
@@ -594,7 +594,8 @@ def make_from_dataset_path(dataset_path="/",
                                           isclass=False)
 
     # Finally instantiate env from config & overrides
-    env = Environment(init_grid_path=grid_path_abs,
+    env = Environment(init_env_path=os.path.abspath(dataset_path),
+                      init_grid_path=grid_path_abs,
                       chronics_handler=data_feeding,
                       backend=backend,
                       parameters=param,

--- a/grid2op/MakeEnv/UpdateEnv.py
+++ b/grid2op/MakeEnv/UpdateEnv.py
@@ -85,7 +85,7 @@ def _do_env_need_update(env_name, env_hashes):
         # no hash for this environment is provided, i don't know, so in doubt i need to update it (old behaviour)
         return True
     else:
-        # i check if "my" hash is different that the remote hash
+        # i check if "my" hash is different from the remote hash
         base_path = grid2op.get_current_local_dir()
         hash_remote_hex = env_hashes[env_name]
         hash_local = _hash_env(os.path.join(base_path, env_name))
@@ -133,6 +133,8 @@ def _update_files(env_name=None,
                 dict_main = answer_json[env_name]
                 for k, dict_ in dict_main.items():
                     _update_file(dict_, env_name, file_name=k)
+            elif need_update and env_name not in answer_json:
+                print(f"Environment: \"{env_name}\" is not up to date, but we did not found any files to update. Please write an issue at https://github.com/rte-france/Grid2Op/issues/new?assignees=&labels=bug&template=bug_report.md&title=")
             else:
                 # environment is up to date
                 print("Environment \"{}\" is up to date".format(env_name))

--- a/grid2op/Observation/_ObsEnv.py
+++ b/grid2op/Observation/_ObsEnv.py
@@ -45,6 +45,7 @@ class _ObsEnv(BaseEnv):
     This class is reserved for internal use. Do not attempt to do anything with it.
     """
     def __init__(self,
+                 init_env_path,
                  init_grid_path,
                  backend_instanciated,
                  parameters,
@@ -66,6 +67,7 @@ class _ObsEnv(BaseEnv):
                  _ptr_orig_obs_space=None
                  ):
         BaseEnv.__init__(self,
+                         init_env_path,
                          init_grid_path,
                          copy.deepcopy(parameters),
                          thermal_limit_a,
@@ -579,5 +581,6 @@ class _ObsEnv(BaseEnv):
                         "_limit_curtailment_init", "_gen_before_curtailment_init", "_sum_curtailment_mw_init",
                         "_sum_curtailment_mw_prev_init", "_nb_time_step_init", "_attention_budget_state_init",
                         "_max_episode_duration", "_ptr_orig_obs_space"]:
-            delattr(self, attr_nm)
+            if hasattr(self, attr_nm):
+                delattr(self, attr_nm)
             setattr(self, attr_nm, None)

--- a/grid2op/Observation/observationSpace.py
+++ b/grid2op/Observation/observationSpace.py
@@ -97,7 +97,8 @@ class ObservationSpace(SerializableObservationSpace):
         _ObsEnv_class = _ObsEnv.init_grid(type(env.backend), force_module=_ObsEnv.__module__)
         _ObsEnv_class._INIT_GRID_CLS = _ObsEnv  # otherwise it's lost
         setattr(sys.modules[_ObsEnv.__module__], _ObsEnv_class.__name__, _ObsEnv_class)
-        self.obs_env = _ObsEnv_class(init_grid_path=None,  # don't leak the path of the real grid to the observation space
+        self.obs_env = _ObsEnv_class(init_env_path=None,  # don't leak the path of the real grid to the observation space
+                                     init_grid_path=None,  # don't leak the path of the real grid to the observation space
                                      backend_instanciated=self._backend_obs,
                                      obsClass=CompleteObservation,  # do not put self.observationClass otherwise it's initialized twice
                                      parameters=self._simulate_parameters,

--- a/grid2op/Runner/runner.py
+++ b/grid2op/Runner/runner.py
@@ -221,6 +221,7 @@ class Runner(object):
     FORCE_SEQUENTIAL = "GRID2OP_RUNNER_FORCE_SEQUENTIAL"
 
     def __init__(self,
+                 init_env_path: str,
                  init_grid_path: str,
                  path_chron,  # path where chronics of injections are stored
                  name_env="unknown",
@@ -444,6 +445,7 @@ class Runner(object):
             self.logger = logger.getChild("grid2op_Runner")
 
         # store _parameters
+        self.init_env_path = init_env_path
         self.init_grid_path = init_grid_path
         self.names_chronics_to_backend = names_chronics_to_backend
 
@@ -528,7 +530,8 @@ class Runner(object):
     def _new_env(self, chronics_handler, parameters):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            res = self.envClass(init_grid_path=self.init_grid_path,
+            res = self.envClass(init_env_path=self.init_env_path,
+                                init_grid_path=self.init_grid_path,
                                 chronics_handler=chronics_handler,
                                 backend=self.backendClass(),
                                 parameters=parameters,

--- a/grid2op/gym_compat/gym_act_space.py
+++ b/grid2op/gym_compat/gym_act_space.py
@@ -96,7 +96,10 @@ class GymActionSpace(_BaseGymSpaceConverter):
                             "_maintenance": "maintenance",
                             "_storage_power": "storage_power",
                             "_curtail": "curtail",
-                            "_raise_alarm": "raise_alarm"
+                            "_raise_alarm": "raise_alarm",
+                            'shunt_p': '_shunt_p',
+                            'shunt_q': '_shunt_q',
+                            'shunt_bus': '_shunt_bus',
                             }
     keys_human_2_grid2op = {v: k for k, v in keys_grid2op_2_human.items()}
 

--- a/grid2op/gym_compat/gymenv.py
+++ b/grid2op/gym_compat/gymenv.py
@@ -64,7 +64,7 @@ class GymEnv(gym.Env):
         self.init_env.render(mode=mode)
 
     def close(self):
-        if hasattr(self, "init_env") and self.init_env is None:
+        if hasattr(self, "init_env") and self.init_env is not None:
             self.init_env.close()
             del self.init_env
         self.init_env = None

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -1135,6 +1135,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             warnings.filterwarnings("ignore")
             env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                               backend=self.backend,
+                              init_env_path=os.path.join(self.path_matpower, self.case_file),
                               chronics_handler=self.chronics_handler,
                               parameters=self.env_params,
                               name="test_pp_env1")
@@ -1152,6 +1153,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = Environment(init_grid_path=os.path.join(self.path_matpower, case_file),
+                              init_env_path=os.path.join(self.path_matpower, case_file),
                               backend=self.backend,
                               chronics_handler=self.chronics_handler,
                               parameters=env_params,
@@ -1183,6 +1185,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             warnings.filterwarnings("ignore")
             env = Environment(init_grid_path=os.path.join(self.path_matpower, case_file),
                               backend=self.backend,
+                              init_env_path=os.path.join(self.path_matpower, case_file),
                               chronics_handler=self.chronics_handler,
                               parameters=self.env_params,
                               name="test_pp_env3")
@@ -1222,6 +1225,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             warnings.filterwarnings("ignore")
             env = Environment(init_grid_path=os.path.join(self.path_matpower, case_file),
                               backend=self.backend,
+                              init_env_path=os.path.join(self.path_matpower, case_file),
                               chronics_handler=self.chronics_handler,
                               parameters=env_params,
                               name="test_pp_env4")
@@ -1263,6 +1267,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             env = Environment(init_grid_path=os.path.join(self.path_matpower, case_file),
                               backend=self.backend,
                               chronics_handler=self.chronics_handler,
+                              init_env_path=os.path.join(self.path_matpower, case_file),
                               parameters=env_params,
                               name="test_pp_env5")
         with warnings.catch_warnings():
@@ -1300,6 +1305,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             env = Environment(init_grid_path=os.path.join(self.path_matpower, case_file),
                               backend=self.backend,
                               chronics_handler=self.chronics_handler,
+                              init_env_path=os.path.join(self.path_matpower, case_file),
                               parameters=env_params,
                               name="test_pp_env6")
         with warnings.catch_warnings():
@@ -1338,6 +1344,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             env = Environment(init_grid_path=os.path.join(self.path_matpower, case_file),
                               backend=self.backend,
                               chronics_handler=self.chronics_handler,
+                              init_env_path=os.path.join(self.path_matpower, case_file),
                               parameters=env_params,
                               name="test_pp_env7")
         with warnings.catch_warnings():

--- a/grid2op/tests/BaseRedispTest.py
+++ b/grid2op/tests/BaseRedispTest.py
@@ -63,6 +63,7 @@ class BaseTestRedispatch(MakeBackend):
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.backend,
+                                   init_env_path=self.path_matpower,
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
                                    names_chronics_to_backend=self.names_chronics_to_backend,
@@ -328,6 +329,7 @@ class BaseTestRedispatchChangeNothingEnvironment(MakeBackend):
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.backend,
+                                   init_env_path=self.path_matpower,
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
                                    names_chronics_to_backend=self.names_chronics_to_backend,

--- a/grid2op/tests/test_Environment.py
+++ b/grid2op/tests/test_Environment.py
@@ -76,6 +76,7 @@ class TestLoadingBackendPandaPower(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
+                                   init_env_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.backend,
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
@@ -90,7 +91,6 @@ class TestLoadingBackendPandaPower(unittest.TestCase):
 
     def test_copy_env(self):
         # first copying method
-
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             cpy = Environment(**self.env.get_kwargs())
@@ -220,6 +220,7 @@ class TestLoadingBackendPandaPower(unittest.TestCase):
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.get_backend(),
+                                   init_env_path=os.path.join(self.path_matpower, self.case_file),
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
                                    rewardClass=L2RPNReward,

--- a/grid2op/tests/test_EnvironmentCpy.py
+++ b/grid2op/tests/test_EnvironmentCpy.py
@@ -19,12 +19,18 @@ from grid2op.tests.helper_path_test import *
 
 from grid2op.Reward import L2RPNReward
 from grid2op.MakeEnv import make
-from grid2op.tests.test_Environment import (TestLoadingBackendPandaPower, TestIllegalAmbiguous, TestOtherReward,
-                                            TestResetOk, TestLineChangeLastBus, TestResetAfterCascadingFailure,
-                                            TestCascadingFailure, TestLoading2envDontCrash,
-                                            TestDeactivateForecast, TestMaxIter
+from grid2op.tests.test_Environment import (TestLoadingBackendPandaPower as Aux_TestLoadingBackendPandaPower,
+                                            TestIllegalAmbiguous as Aux_TestIllegalAmbiguous,
+                                            TestOtherReward as Aux_TestOtherReward,
+                                            TestResetOk as Aux_TestResetOk,
+                                            TestLineChangeLastBus as Aux_TestLineChangeLastBus,
+                                            TestResetAfterCascadingFailure as Aux_TestResetAfterCascadingFailure,
+                                            TestCascadingFailure as Aux_TestCascadingFailure,
+                                            TestLoading2envDontCrash as Aux_TestLoading2envDontCrash,
+                                            TestDeactivateForecast as Aux_TestDeactivateForecast, 
+                                            TestMaxIter as Aux_TestMaxIter,
                                             )
-from grid2op.tests.test_Agent import TestAgent
+from grid2op.tests.test_Agent import TestAgent as Aux_TestAgent
 
 DEBUG = False
 PROFILE_CODE = False
@@ -32,28 +38,28 @@ if PROFILE_CODE:
     import cProfile
 
 
-class TestLoadingBackendPandaPowerCopy(TestLoadingBackendPandaPower):
+class TestLoadingBackendPandaPowerCopy(Aux_TestLoadingBackendPandaPower):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestIllegalAmbiguousCopy(TestIllegalAmbiguous):
+class TestIllegalAmbiguousCopy(Aux_TestIllegalAmbiguous):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestOtherRewardCopy(TestOtherReward):
+class TestOtherRewardCopy(Aux_TestOtherReward):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestResetOkCopy(TestResetOk):
+class TestResetOkCopy(Aux_TestResetOk):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
@@ -70,28 +76,28 @@ class TestResetOkCopy(TestResetOk):
         super().test_reset_after_blackout_withdetailed_info(env=env.copy())
 
 
-class TestLineChangeLastBusCopy(TestLineChangeLastBus):
+class TestLineChangeLastBusCopy(Aux_TestLineChangeLastBus):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestResetAfterCascadingFailureCopy(TestResetAfterCascadingFailure):
+class TestResetAfterCascadingFailureCopy(Aux_TestResetAfterCascadingFailure):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestCascadingFailureCopy(TestCascadingFailure):
+class TestCascadingFailureCopy(Aux_TestCascadingFailure):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestLoading2envDontCrashCopy(TestLoading2envDontCrash):
+class TestLoading2envDontCrashCopy(Aux_TestLoading2envDontCrash):
     def setUp(self):
         super().setUp()
         self.env1_orig = self.env1
@@ -100,21 +106,21 @@ class TestLoading2envDontCrashCopy(TestLoading2envDontCrash):
         self.env2 = self.env2.copy()
 
 
-class TestDeactivateForecastCopy(TestDeactivateForecast):
+class TestDeactivateForecastCopy(Aux_TestDeactivateForecast):
     def setUp(self):
         super().setUp()
         self.env1_orig = self.env1
         self.env1 = self.env1.copy()
 
 
-class TestMaxIterCopy(TestMaxIter):
+class TestMaxIterCopy(Aux_TestMaxIter):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env
         self.env = self.env.copy()
 
 
-class TestAgentCopy(TestAgent):
+class TestAgentCopy(Aux_TestAgent):
     def setUp(self):
         super().setUp()
         self.env_orig = self.env

--- a/grid2op/tests/test_EpisodeData.py
+++ b/grid2op/tests/test_EpisodeData.py
@@ -72,6 +72,7 @@ class TestEpisodeData(unittest.TestCase):
         self.gridStateclass = Multifolder
         self.backendClass = PandaPowerBackend
         self.runner = Runner(init_grid_path=self.init_grid_path,
+                             init_env_path=self.init_grid_path,
                              path_chron=self.path_chron,
                              parameters_path=self.parameters_path,
                              names_chronics_to_backend=self.names_chronics_to_backend,
@@ -127,6 +128,7 @@ class TestEpisodeData(unittest.TestCase):
     def test_collection_wrapper_after_run(self):
         OneChange = OneChangeThenNothing.gen_next({"set_bus": {"lines_or_id": [(1,-1)]}})
         runner = Runner(init_grid_path=self.init_grid_path,
+                        init_env_path=self.init_grid_path,
                         path_chron=self.path_chron,
                         parameters_path=self.parameters_path,
                         names_chronics_to_backend=self.names_chronics_to_backend,

--- a/grid2op/tests/test_ObservationHazard_Maintenance.py
+++ b/grid2op/tests/test_ObservationHazard_Maintenance.py
@@ -100,6 +100,7 @@ class TestObservationHazard(unittest.TestCase):
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.backend,
+                                   init_env_path=os.path.join(self.path_matpower, self.case_file),
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
                                    names_chronics_to_backend=self.names_chronics_to_backend,
@@ -180,6 +181,7 @@ class TestObservationMaintenance(unittest.TestCase):
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.backend,
+                                   init_env_path=os.path.join(self.path_matpower, self.case_file),
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
                                    names_chronics_to_backend=self.names_chronics_to_backend,

--- a/grid2op/tests/test_Rules.py
+++ b/grid2op/tests/test_Rules.py
@@ -66,6 +66,7 @@ class TestLoadingBackendFunc(unittest.TestCase):
             warnings.filterwarnings("ignore")
             self.env = Environment(init_grid_path=os.path.join(self.path_matpower, self.case_file),
                                    backend=self.adn_backend,
+                                   init_env_path=os.path.join(self.path_matpower, self.case_file),
                                    chronics_handler=self.chronics_handler,
                                    parameters=self.env_params,
                                    names_chronics_to_backend=self.names_chronics_to_backend,

--- a/grid2op/tests/test_Runner.py
+++ b/grid2op/tests/test_Runner.py
@@ -62,6 +62,7 @@ class TestRunner(HelperTests):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")  # silence the warning about missing layout
             self.runner = Runner(init_grid_path=self.init_grid_path,
+                                 init_env_path=self.init_grid_path,
                                  path_chron=self.path_chron,
                                  parameters_path=self.parameters_path,
                                  names_chronics_to_backend=self.names_chronics_to_backend,

--- a/grid2op/tests/test_issue_274.py
+++ b/grid2op/tests/test_issue_274.py
@@ -11,7 +11,7 @@ import grid2op
 import unittest
 import numpy as np
 
-class Issue245Tester(unittest.TestCase):
+class Issue274Tester(unittest.TestCase):
     def setUp(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
@@ -52,6 +52,3 @@ class Issue245Tester(unittest.TestCase):
             cpy_line_attacked = np.where(info_cpy["opponent_attack_line"])[0]
             assert init_line_attacked == line_attacked, f"wrong line attack at iteration {i}"
             assert init_line_attacked == cpy_line_attacked, f"wrong line attack at iteration {i} for the copy env"
-
-
-    

--- a/grid2op/tests/test_issue_281.py
+++ b/grid2op/tests/test_issue_281.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+import unittest
+import grid2op
+import warnings
+from grid2op.Action import CompleteAction
+from grid2op.gym_compat import GymEnv
+
+
+class Issue281Tester(unittest.TestCase):
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("educ_case14_storage", test=True, action_class=CompleteAction)
+
+    def tearDown(self):
+        self.env.close()
+
+    def test_can_make(self):
+        """test that the opponent state is correctly copied"""
+        gym_env = GymEnv(self.env)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grid2op/tests/test_issue_282.py
+++ b/grid2op/tests/test_issue_282.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+import unittest
+import warnings
+
+import grid2op
+from grid2op.Action import CompleteAction
+from grid2op.gym_compat import GymEnv
+from grid2op.gym_compat import BoxGymActSpace
+
+
+class Issue282Tester(unittest.TestCase):
+    def setUp(self):
+        self._default_act_attr_to_keep = ["redispatch", "curtail", "set_storage"]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("educ_case14_storage", test=True, action_class=CompleteAction)
+        self.env_gym = GymEnv(self.env)
+    
+        self.env_gym.action_space.close()
+        self.env_gym.action_space = BoxGymActSpace(self.env.action_space, attr_to_keep=self._default_act_attr_to_keep)
+        self.env_gym.seed(0)
+
+    def tearDown(self):
+        self.env.close()
+        self.env_gym.close()
+
+    def test_can_make(self):
+        """test that the opponent state is correctly copied"""
+        act = self.env_gym.action_space.from_gym(self.env_gym.action_space.sample())
+        obs, reward, done, info = self.env.step(act)
+        assert len(info["exception"]) == 0, f"{info['exception'] = }"
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grid2op/tests/test_issue_283.py
+++ b/grid2op/tests/test_issue_283.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import unittest
+import warnings
+
+import grid2op
+from grid2op.Rules.AlwaysLegal import AlwaysLegal
+from grid2op.gym_compat import GymEnv
+from grid2op.gym_compat import BoxGymActSpace
+
+
+class Issue283Tester(unittest.TestCase):
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("educ_case14_storage", test=True, gamerules_class=AlwaysLegal)
+            self.env_gym = GymEnv(self.env)
+    
+        self.env_gym.action_space.close()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env_gym.action_space = BoxGymActSpace(self.env.action_space)
+        self.env_gym.seed(0)
+
+    def tearDown(self):
+        self.env.close()
+        self.env_gym.close()
+
+    def test_can_make(self):
+        """test that the opponent state is correctly copied"""
+        gym_act = self.env_gym.action_space.sample()
+        gym_act[:self.env.n_line] = 0.  # do not change line status ! (otherwise it diverges)
+        act = self.env_gym.action_space.from_gym(gym_act)
+        obs, reward, done, info = self.env.step(act)
+        assert len(info["exception"]) == 0, f"{info['exception'] = }"
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [BREAKING] in the "gym_compat" module the curtailment action type has 
  for dimension the number of dispatchable generators (as opposed to all generators
  before) this was mandatory to fix issue https://github.com/rte-france/Grid2Op/issues/282
- [BREAKING] the size of the continuous action space for the redispatching in
  case of gym compatibility has also been adjusted to be consistent with curtailment.
  Before it has the size of `env.n_gen` now `np.sum(env.gen_redispatchable)`.
- [FIXED] a bug in the gym action space: see issue https://github.com/rte-france/Grid2Op/issues/281
- [FIXED] a bug in the gym box action space: see issue https://github.com/rte-france/Grid2Op/issues/283
- [IMPROVED] better difference between env_path and grid_path in environments.

