### PR TITLE
Upgrade to version 1.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
                 command: |
                   source venv_test/bin/activate
                   pip install -e .[test]
+                  export _GRID2OP_FORCE_TEST=1
                   cd grid2op/tests/
                   python3 helper_list_test.py | circleci tests split > /tmp/tests_run
                   python3 -m unittest $(cat /tmp/tests_run)
@@ -63,12 +64,14 @@ jobs:
                     pip install -U numba
                     pip install -U "numpy>=1.18,<1.19"
                     pip install -U .[test]
+                    export _GRID2OP_FORCE_TEST=1
                     grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    pip install -U "numpy>=1.19,<1.20"
                    pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
     install37:
         executor: python37
@@ -91,24 +94,28 @@ jobs:
                     pip install -U numba
                     pip install -U "numpy>=1.18,<1.19"
                     pip install -U .[test]
+                    export _GRID2OP_FORCE_TEST=1
                     grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    pip install -U "numpy>=1.19,<1.20"
                    pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    pip install -U "numpy>=1.20,<1.21"
                    pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    pip install -U "numpy>=1.21,<1.22"
                    pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
     install38:
         executor: python38
@@ -131,30 +138,35 @@ jobs:
                     python -m pip install -U numba
                     python -m pip install -U "numpy>=1.18,<1.19"
                     python -m pip install -U .[test]
+                    export _GRID2OP_FORCE_TEST=1
                     grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.19,<1.20"
                    python -m pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.20,<1.21"
                    python -m pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.21,<1.22"
                    python -m pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.22,<1.23"
                    python -m pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
     install39:
         executor: python39
@@ -169,6 +181,7 @@ jobs:
             - run: python -m virtualenv venv_test
             - run:
                command: |
+                   export _GRID2OP_FORCE_TEST=1
                    source venv_test/bin/activate
                    python -m pip install -U pip setuptools wheel
                    python -m pip install chronix2grid>="1.1.0.post1"
@@ -179,12 +192,14 @@ jobs:
                    python -m pip install -U .[test]
             - run:
                command: |
+                   export _GRID2OP_FORCE_TEST=1
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.19,<1.20"
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
+                   export _GRID2OP_FORCE_TEST=1
                    python -m pip install -U "numpy>=1.20,<1.21"
                    grid2op.testinstall
             - run:
@@ -195,6 +210,7 @@ jobs:
             - run:
                command: |
                    source venv_test/bin/activate
+                   export _GRID2OP_FORCE_TEST=1
                    python -m pip install -U "numpy>=1.22,<1.23"
                    grid2op.testinstall
     install310:
@@ -217,12 +233,14 @@ jobs:
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.21,<1.22"
                    python -m pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
                    python -m pip install -U "numpy>=1.22,<1.23"
                    python -m pip install -U .[test]
+                   export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
 
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -355,6 +355,8 @@ venv_test/
 getting_started/saved_agent_PPO_*_results/
 grid2op/data/**/_grid2op_classes/
 test_issue_glop.py
+**.swp
+grid2op/tests/test_report.txt
 
 # profiling files
 **.prof

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,9 +42,12 @@ Change Log
   (see https://github.com/rte-france/Grid2Op/issues/340)
 - [FIXED] an issue with `act0 + act1` when curtailment was applied 
   (see https://github.com/rte-france/Grid2Op/issues/340)
+- [FIXED] a slight "bug" in the formula to compute the redispatching cost for L2RPN 2022 competition.
 - [IMPROVED] possibility to pass the env variable `_GRID2OP_FORCE_TEST` to force the flag
    of "test=True" when creating an environment. This is especially useful when testing to prevent
    downloading of data.
+- [IMPROVED] support of "kwargs" backend arguments in `MultiMixEnv` see first
+  item of version 1.7.1 below
 
 [1.7.1] - 2022-06-03
 -----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,17 @@ Change Log
 - [???] "asynch" multienv
 - [???] properly model interconnecting powerlines
 
+
+[1.7.2] - 2022-xx-yy
+--------------------
+- [FIXED] seeding issue https://github.com/rte-france/Grid2Op/issues/331
+- [FIXED] clarify doc about fixed size matrices / graphs https://github.com/rte-france/Grid2Op/issues/330
+- [FIXED] improved the behaviour of `obs._get_bus_id` and `obs._aux_fun_get_bus` : when some objects were on busbar 2
+  they had a "wrong" bus id (it was lagged by 1) meaning an empty "bus" was introduced.
+- [IMPROVED] possibility to pass the env variable `_GRID2OP_FORCE_TEST` to force the flag
+   of "test=True" when creating an environment. This is especially useful when testing to prevent
+   downloading of data.
+
 [1.7.1] - 2022-06-03
 -----------------------
 - [BREAKING] The possibility to propagate keyword arguments between the environment

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,10 @@ Change Log
 - [FIXED] clarify doc about fixed size matrices / graphs https://github.com/rte-france/Grid2Op/issues/330
 - [FIXED] improved the behaviour of `obs._get_bus_id` and `obs._aux_fun_get_bus` : when some objects were on busbar 2
   they had a "wrong" bus id (it was lagged by 1) meaning an empty "bus" was introduced.
+- [FIXED] an issue with `obs.state_of(...)` when inspecting storage units 
+  (see https://github.com/rte-france/Grid2Op/issues/340)
+- [FIXED] an issue with `act0 + act1` when curtailment was applied 
+  (see https://github.com/rte-france/Grid2Op/issues/340)
 - [IMPROVED] possibility to pass the env variable `_GRID2OP_FORCE_TEST` to force the flag
    of "test=True" when creating an environment. This is especially useful when testing to prevent
    downloading of data.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, RTE France'
 author = 'Benjamin Donnot'
 
 # The full version, including alpha/beta/rc tags
-release = '1.7.1'
+release = '1.7.2.rc1'
 version = '1.7'
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, RTE France'
 author = 'Benjamin Donnot'
 
 # The full version, including alpha/beta/rc tags
-release = '1.7.2.rc1'
+release = '1.7.2.rc2'
 version = '1.7'
 
 

--- a/docs/grid_graph.rst
+++ b/docs/grid_graph.rst
@@ -35,8 +35,11 @@ Description of a powergrid adopting the "graph" representation
 A powergrid can be represented as a "graph" (in the mathematical meaning) where:
 
 - nodes / vertices are represented by "buses" (or "busbars"): that is the place that different elements of the grid
-  are interconnected
-- links / edges are represented by "powerlines".
+  are interconnected. Only "connected" buses are represented in this graph. This means that if no element (*eg* no lines, 
+  no loads, no generators, no storage units etc.) is connected to a busbar, then it will not be present in this graph.
+- links / edges are represented by "powerlines". Usually, for a graph, it is convenient that there is no "parallel edges".
+  This is a property we want to ensure here and this is why when there is 2 powerlines connecting the same buses, they are 
+  merged into one edges in this graph.
 
 Nodes attributes
 ~~~~~~~~~~~~~~~~~~
@@ -85,11 +88,23 @@ The edges of this graph have attributes:
 - "theta_or": (optional) the voltage angle at the origin side of the powerline
 - "theta_ex": (optional) the voltage angle at the extremity side of the powerline
 
-**NB** A convention needs to be chosen (without loss of generality) for the orientation of the powerlines. When
-adopting the "graph representation" powerlines are oriented in this manner: if a powerline is connected at substation
-`j` on one side and at substation `k` on the other and `j < k`, then its origin side will be on the `j` side
-and its extremity side will be attached to `k`. To make it clear: if a powerline connects substation 12 to 14, then
-its origin side will be connected to 12 and it's origin side to 14.
+.. warning::
+  A convention needs to be chosen (without loss of generality) for the orientation of the powerlines. When
+  adopting the "graph representation" powerlines are oriented in this manner: if a powerline is connected at substation
+  `j` on one side and at substation `k` on the other and `j < k`, then its origin side will be on the `j` side
+  and its extremity side will be attached to `k`. To make it clear: if an edges connects substation 12 to 14, then
+  its origin side will be connected to 12 and it's origin side to 14.
+
+.. alertblock::
+  The size of this graph (both numuber of edges and number of nodes) can change during the same episode. This will be
+  the case if you perform a topological action (for example assigning some elements to the busbar 2 of a substation and
+  no elements were connected to this busbar beforehand): in this case, the graph will count one more node.
+
+.. warning::
+  By convention, if the observation corresponds to a "game over", then this graph will have only one node and no edge at all.
+
+  This is a convention made in grid2op to ensure some properties about the returned value of the function `obs.as_networkx()`.
+  Mathematically speaking, in such case, the graph would be empty (no connected bus).
 
 Some clarifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -116,14 +131,15 @@ Physical equations
 +++++++++++++++++++++
 All these variables are not independant from one another regardless of the "power system modeling" adopted.
 
-Generally speaking:
+Generally speaking, the graph meets the KCL (Kirchhoff Current Law):
 
 - if you know "v" and "theta" at both sides of the powerline, you can deduce all the "p_or", "q_or",
-  "v_or", "theta_or", "p_ex", "q_ex", "v_ex" and "theta_ex"
--  at each bus, the sum of all the "p_or" and "p_ex" and "p" is equal to 0.
+  "v_or", "theta_or", "p_ex", "q_ex", "v_ex" and "theta_ex" (knowing some "physical" parameters of the powerlines 
+  that are not known directly in the grid2op observation but are "somewhere" in the backend.)
+- at each bus, the sum of all the "p_or" and "p_ex" and "p" is equal to 0.
 - at each bus, the sum of all the "q_or" and "q_ex" and "q" is equal to 0.
 
-Actually, it is by solving these constraints that everything is computed.
+Actually, it is by solving these constraints that "everything" is computed by the backend.
 
 .. note::
 
@@ -145,26 +161,33 @@ The grid is immutable
 +++++++++++++++++++++++
 Grid2op aims at modeling grid2op operation close to real time.
 
-This is why the powergrid is considered as "fixed" or "immutable". For example, if for a given environment load
+This is why the powergrid is considered as "fixed" or "immutable" (in the sense that you cannot build new equipment). 
+For example, if for a given environment load
 with id `j` is connected to substation with id `k` then for all the episodes on this environment, this will
-be the case (load cannot be magically connected to another substation).
+be the case (load cannot be magically connected to another substation), but of course, in this case, this load 
+can be switched to either busbar 1 or busbar 2 of its substation `k`. 
 
 This is a property of power system: a load representing a city, in real time, it is not possible to move completly
-a city from one place of a state to another. And even if it was possible, it is definitely not desirable.
+a city from one place of a State to another. And even if it was possible, it is definitely not desirable (imagine the 
+situation: you get back from work to your home, but your house has moved 250km / 200 miles North ...)
 
 This applies to all elements of the grid. For the same environment:
 
-- load will always be connected at the same substation
-- generator will always be connected at the same substation
-- storage units will always be connected at the same substation
+- no load will appear / disappear on the grid (=> `type(env).n_load` never change)
+- load will always be connected at the same substation (=> `type(env).load_to_subid` never change)
+- no generator will appear / disappear on the grid (=> `type(env).n_gen` never change)
+- generator will always be connected at the same substation  (=> `type(env).gen_to_subid` never change)
+- no storage units will appear / disappear on the grid (=> `type(env).n_storage` never change)
+- storage units will always be connected at the same substation (=> `type(env).storage_to_subid` never change)
+- no powerline will appear / disappear on the grid (=> `type(env).n_line` never change)
 - powerlines will always connects the same substations, and in this case, grid2op also offer the guarantee that
   origin side will always be connected at the same substation AND extremity side will always be connected at
   the same substation. In other words, the orientation convention adopted to define "origin side" and
-  "extremity side" is part of the environment.
+  "extremity side" is part of the environment. (=> `type(env).line_or_to_subid` and `type(env).line_ex_to_subid` never change)
 
 .. warning::
 
-    If you decide to code a new Backend class, then you need to meet this property. Otherwise things might break.
+    If you decide to code a new `Backend` class, then you need to meet this property. Otherwise things might break.
 
 Not everything can be connected together
 +++++++++++++++++++++++++++++++++++++++++++
@@ -176,12 +199,13 @@ production unit at the South West of the same sate.
 To adopt a more precise vocabulary, only elements (load, generator, storage unit, origin side of a powerline,
 extremity side of a powerline) that are at the same substation can be directly connected together.
 
-If an element of the grid is connected at substation `j` and another one at substation `k` for a given environment,
-in absolutely no circumstances these two objects can be directly connected together, they will never be connected at
-the same bus.
+If an element of the grid is connected at substation `j` and another one at substation `k` (with `j` different `k`) 
+for a given environment, in absolutely no circumstances these two objects can be directly connected together, 
+they will never be connected at the same bus.
 
 To state this constraint a bit differently, a substation can be split in independent buses (multiple nodes
-at the same substation) but a nodes can only connect elements of the same substation.
+at the same substation) but a bus can only connect elements of the same substation: substation `j` and 
+substation `k` (with `j` different `k`) will never have a "bus" in common.
 
 .. note::
 
@@ -189,16 +213,18 @@ at the same substation) but a nodes can only connect elements of the same substa
     given substation at time of writing (April 2021).
 
     Changing this would not be too difficult on grid2op side, but would make the action space even bigger. If you
-    really need to use more than 2 buses at the same substation, do not hesitate to fill a feature request.
+    really need to use more than 2 buses at the same substation, do not hesitate to fill a feature request: 
+    https://github.com/rte-france/Grid2Op/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
+
 
 The graph is dynamic
 ++++++++++++++++++++++
 Even though an element is always, under all circumstances, connected at the same substation, it can be connected
-at different buses (of this substation) at different step. This is even the main "flexibility" that is studied
+at different buses (of its substation) at different step. This is even the main "flexibility" that is studied
 with grid2op.
 
 This implies that "the" graph representing the powergrid does not always have the same number of nodes depending
-on the time, nor the same number of edges, for example if powerlines are disconnected.
+on the step, nor the same number of edges, for example if powerlines are disconnected.
 
 .. note::
 
@@ -213,17 +239,19 @@ on the time, nor the same number of edges, for example if powerlines are disconn
     powergrid. The removal of breaker is another simplification made for clarity.
 
     If you want to model these, it is perfectly possible without too much trouble. You can fill a feature request
-    for this if that is interesting to you.
+    for this if that is interesting to you :
+    https://github.com/rte-france/Grid2Op/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
 
-.. note::
+.. warning::
 
-    The graph of the grid has also the property that more than one edge can connect the same pair of buses (it is
-    the case for parallel powerlines)
+    The graph of the grid has also the property that more than one powerline can connect the same pair of buses (it is
+    the case for parallel powerlines). In this case, these powerlines are "merged" together to get a graph without 
+    parralel edges.
 
 Wrapping it up
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The "sequential decision making" modeled by the grid2op aims then at finding good actions to keep the grid in safety
-(flows <= thermal limits on all powerlines) while allowing consumer to consume as much power as they want.
+(`flows <= thermal limits` on all powerlines) while allowing consumer to consume as much power as they want.
 
 The possible actions are:
 
@@ -231,6 +259,7 @@ The possible actions are:
 - changing the "topology" of some substations, which consists in merging or splitting buses at some substations
 - changing the amount of power some storage units produce / absorb
 - changing the production setpoint of the generators (aka redispatching or curtailment)
+- producing or absorbing power from storage units.
 
 For more information, technical details are provided in page :ref:`action-module`
 
@@ -270,8 +299,8 @@ And then, in the observation, you can retrieve the state of each object in the "
 (see :attr:`grid2op.Observation.BaseObservation.topo_vect` for more information).
 
 As an exemple, say `obs.topo_vect[42] = 2` it means that the "42nd" element (remember in python index are 0 based,
-this is why i put quote on "42nd", this is actually the 43rd... but writing 43rd is more confusing, so we will
-stick to "42nd") of the grid is connected to bus 2.
+this is why I put quote on "42nd", this is actually the 43rd... but writing 43rd is more confusing, so we will
+stick to "42nd") of the grid is connected to busbar 2 at its substation.
 
 To know what element of the grid is the "42nd", you can:
 
@@ -286,6 +315,12 @@ To know what element of the grid is the "42nd", you can:
    is not of that type, and otherwise and id > 0. Taking the same example as for the above bullet point!
    `env.grid_objects_types[42,:] = [sub_id, -1, -1, -1, line_id, -1]` meaning the "42nd" element of the grid
    if the extremity end (because it's the 5th column) of id `line_id` (the other element being marked as "-1").
+
+.. note::
+  As of a few versions of grid2op, if you are interested at the busbar to which (say) load 5 is connected, then Instead
+  of having to write `obs.topo_vect[obs.load_pos_topo_vect[5]]` you can directly call `obs.load_bus[5]` (the same applies
+  naturally to the other types of objects: *eg* `obs.gen_bus[...]`, `obs.line_or_bus` etc.).
+
 
 .. _get-the-graph-gridgraph:
 
@@ -333,8 +368,17 @@ Graph1: the "normal graph"
 Because we don't really find fancy name for it, let's call it the "normal" graph of the grid. This graph, you
 might have guessed is the graph defined at the very top of this page of the documentation.
 
-Each edge is a powerline and each node is a "bus" (remember: by definition two objects are directly
+Each edge is "a" powerline and each node is a "bus" (remember: by definition two objects are directly
 connected together if they are connected at the same "bus").
+
+.. note:: 
+  As stated in the first paragraph of this page:
+  
+  - an edge of this graph is actually made of multiple powerline "fused" together to avoid issues with "parallele edge"
+  - if a bus is disconnected, it is not present on this graph. The number of nodes can change.
+  - this graph should be "empty" if the observation comes from a "game over", but it is actually a graph with no
+    edge and one single node.
+     
 
 This graph can be retrieved using the `obs.as_networkx()` command that returns a networkx graph for the entire
 observation, that has all the attributes described in :ref:`powersystem-desc-gridgraph`.
@@ -359,15 +403,7 @@ You can retrieve it with:
     first_edge = next(iter(state_as_graph.edges))
     print(state_as_graph.edges[first_edge])
 
-.. note::
-
-    The main difference with the "graph of the grid" showed in the first section is that it is a "simple
-    graph" (as opposed to "multi graph"): two parallel edges are merged together.
-
 This graph varies in size: the number of nodes on this graph is the number of bus on the grid !
-
-Effect of an action on this graph
-----------------------------------------------------------------
 
 Now, let's do a topological action on this graph, and print the results:
 
@@ -451,14 +487,14 @@ And this gives:
 |grid_graph_1| |grid_graph_2|
 
 As you see, this action have for effect to split the substation 4 on 2 independent buses (one where there are
-the two red powerline, another where there are the two green)
+the two red powerlines, another where there are the two green)
 
 .. note::
 
     On this example, for this visualization, lots of elements of the grid are not displayed. This is the case
     for the load, generator and storage units for example.
 
-    For an easier to read (and to get! ) representation, feel free to consult the :ref:`grid2op-plot-module`
+    For an easier to read representation, feel free to consult the :ref:`grid2op-plot-module`
 
 .. _graph2-gg:
 
@@ -487,7 +523,9 @@ In the mean time, some documentation are available at :func:`grid2op.Observation
 
     This graph is not represented as a networkx graph, but rather as a symmetrical (sparse) matrix.
 
-    It has no information about flows, but simply about the presence / abscence of powerlines between two buses.
+    It has no information about flows, but simply about the presence / abscence of powerlines between two buses. 
+    
+    Its size can change.
 
 .. _graph4-gg:
 
@@ -501,4 +539,7 @@ In the mean time, some documentation are available at :func:`grid2op.Observation
 
     This graph is not represented as a networkx graph, but rather as a (sparse) matrix.
 
+    Its size can change.
+
 .. include:: final.rst
+  

--- a/grid2op/Action/BaseAction.py
+++ b/grid2op/Action/BaseAction.py
@@ -1252,13 +1252,16 @@ class BaseAction(GridObjects):
 
         # curtailment
         curtailment = other._curtail
-        ok_ind = np.isfinite(curtailment) & np.any(curtailment != -1.0)
+        ok_ind = np.isfinite(curtailment) & (curtailment != -1.0)
         if np.any(ok_ind):
             if "_curtail" not in self.attr_list_set:
                 warnings.warn(
                     type(self).ERR_ACTION_CUT.format("_curtail")
                 )
             else:
+                # new curtailment of the results should be
+                # the curtailment of rhs, only when rhs acts
+                # on curtailment
                 self._curtail[ok_ind] = curtailment[ok_ind]
 
         # set and change status

--- a/grid2op/Environment/BaseEnv.py
+++ b/grid2op/Environment/BaseEnv.py
@@ -1187,7 +1187,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         """
         if self.__closed:
             raise EnvError("This environment is closed. You cannot use it anymore.")
-
+        
         seed_init = None
         seed_chron = None
         seed_obs = None
@@ -1195,38 +1195,43 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         seed_env_modif = None
         seed_volt_cont = None
         seed_opponent = None
+            
         if _seed_me:
+            max_int = np.iinfo(dt_int).max 
+            if seed > max_int:
+                raise Grid2OpException("Seed is too big. Max value is {}, provided value is {}".format(max_int, seed))
+
             try:
                 seed = np.array(seed).astype(dt_int)
             except Exception as exc_:
                 raise Grid2OpException(
                     "Impossible to seed with the seed provided. Make sure it can be converted to a"
-                    "numpy 64 integer."
+                    "numpy 32 bits integer."
                 )
             # example from gym
             # self.np_random, seed = seeding.np_random(seed)
             # inspiration from @ https://github.com/openai/gym/tree/master/gym/utils
             seed_init = seed
             super().seed(seed_init)
-
-        max_int = np.iinfo(dt_int).max
+            
+        max_seed = np.iinfo(dt_int).max  # 2**32 - 1
         if self.chronics_handler is not None:
-            seed = self.space_prng.randint(max_int)
+            seed = self.space_prng.randint(max_seed)
             seed_chron = self.chronics_handler.seed(seed)
         if self._observation_space is not None:
-            seed = self.space_prng.randint(max_int)
+            seed = self.space_prng.randint(max_seed)
             seed_obs = self._observation_space.seed(seed)
         if self._action_space is not None:
-            seed = self.space_prng.randint(max_int)
+            seed = self.space_prng.randint(max_seed)
             seed_action_space = self._action_space.seed(seed)
         if self._helper_action_env is not None:
-            seed = self.space_prng.randint(max_int)
+            seed = self.space_prng.randint(max_seed)
             seed_env_modif = self._helper_action_env.seed(seed)
         if self._voltage_controler is not None:
-            seed = self.space_prng.randint(max_int)
+            seed = self.space_prng.randint(max_seed)
             seed_volt_cont = self._voltage_controler.seed(seed)
         if self._opponent is not None:
-            seed = self.space_prng.randint(max_int)
+            seed = self.space_prng.randint(max_seed)
             seed_opponent = self._opponent.seed(seed)
         self._has_just_been_seeded = True
         return (

--- a/grid2op/MakeEnv/Make.py
+++ b/grid2op/MakeEnv/Make.py
@@ -7,6 +7,7 @@
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
 import time
+from numpy import var
 import requests
 import os
 import warnings
@@ -117,7 +118,19 @@ _EXTRACT_DS_NAME_RECO_ERR = (
 )
 
 def _force_test_dataset():
-    return _VAR_FORCE_TEST in os.environ and int(os.environ[_VAR_FORCE_TEST]) >= 1
+    res = False
+    if _VAR_FORCE_TEST in os.environ:
+        try:
+            var_int = int(os.environ[_VAR_FORCE_TEST])
+        except Exception as exc_:
+            warnings.warn(f"The environment variable {_VAR_FORCE_TEST}, "
+                          f"used to force the \"test=True\" in grid2op "
+                          f"cannot be converted to an integer with error "
+                          f"\"{exc_}\". As it is set nonetheless, we "
+                          f"assume you want to force \"test=True\".")
+            var_int = 1
+        res = var_int >= 1
+    return res
 
 def _send_request_retry(url, nb_retry=10, gh_session=None):
     """

--- a/grid2op/MakeEnv/Make.py
+++ b/grid2op/MakeEnv/Make.py
@@ -19,6 +19,7 @@ import grid2op.MakeEnv.PathUtils
 from grid2op.MakeEnv.PathUtils import _create_path_folder
 from grid2op.Download.DownloadDataset import _aux_download
 
+_VAR_FORCE_TEST = "_GRID2OP_FORCE_TEST"
 
 DEV_DATA_FOLDER = pkg_resources.resource_filename("grid2op", "data")
 DEV_DATASET = os.path.join(DEV_DATA_FOLDER, "{}")
@@ -114,6 +115,8 @@ _EXTRACT_DS_NAME_RECO_ERR = (
     'Impossible to recognize the environment name from path "{}"'
 )
 
+def _force_test_dataset():
+    return _VAR_FORCE_TEST in os.environ and int(os.environ[_VAR_FORCE_TEST]) >= 1
 
 def _send_request_retry(url, nb_retry=10, gh_session=None):
     """
@@ -304,6 +307,12 @@ def make(
 
     """
 
+    if _force_test_dataset():
+        if not test:
+            warnings.warn(f"The environment variable \"{_VAR_FORCE_TEST}\" is defined so grid2op will be forced in \"test\" mode. "
+                          f"This is equivalent to pass \"grid2op.make(..., test=True)\" and prevents any download of data.")
+            test = True
+            
     accepted_kwargs = ERR_MSG_KWARGS.keys() | {"dataset", "test"}
     for el in kwargs:
         if el not in accepted_kwargs:

--- a/grid2op/MakeEnv/Make.py
+++ b/grid2op/MakeEnv/Make.py
@@ -37,6 +37,7 @@ TEST_DEV_ENVS = {
     "l2rpn_case14_sandbox": DEV_DATASET.format("l2rpn_case14_sandbox"),
     "l2rpn_icaps_2021": DEV_DATASET.format("l2rpn_icaps_2021"),
     "l2rpn_wcci_2022_dev": DEV_DATASET.format("l2rpn_wcci_2022_dev"),
+    "l2rpn_wcci_2022": DEV_DATASET.format("l2rpn_wcci_2022_dev"),
     # educational files
     "educ_case14_redisp": DEV_DATASET.format("educ_case14_redisp"),
     "educ_case14_storage": DEV_DATASET.format("educ_case14_storage"),

--- a/grid2op/Observation/baseObservation.py
+++ b/grid2op/Observation/baseObservation.py
@@ -815,7 +815,7 @@ class BaseObservation(GridObjects):
             if storage_id >= self.n_storage:
                 raise Grid2OpException(
                     'There are no storage unit with id "storage_id={}" in this grid.'.format(
-                        line_id
+                        storage_id
                     )
                 )
             if storage_id < 0:
@@ -828,7 +828,7 @@ class BaseObservation(GridObjects):
             res["bus"] = self.topo_vect[self.storage_pos_topo_vect[storage_id]]
             res["sub_id"] = self.storage_to_subid[storage_id]
             if self.support_theta:
-                res["origin"]["theta"] = self.storage_theta[storage_id]
+                res["theta"] = self.storage_theta[storage_id]
         else:
             if substation_id >= len(self.sub_info):
                 raise Grid2OpException(

--- a/grid2op/Observation/baseObservation.py
+++ b/grid2op/Observation/baseObservation.py
@@ -1545,10 +1545,8 @@ class BaseObservation(GridObjects):
         connected = (bus_or > 0) & (bus_ex > 0)
         bus_or = bus_or[connected]
         bus_ex = bus_ex[connected]
-        bus_or += self.line_or_to_subid[connected] + (bus_or - 1) * self.n_sub
-        bus_ex += self.line_ex_to_subid[connected] + (bus_ex - 1) * self.n_sub
-        bus_or -= 1
-        bus_ex -= 1
+        bus_or = self.line_or_to_subid[connected] + (bus_or - 1) * self.n_sub
+        bus_ex = self.line_ex_to_subid[connected] + (bus_ex - 1) * self.n_sub
         unique_bus = np.unique(np.concatenate((bus_or, bus_ex)))
         unique_bus = np.sort(unique_bus)
         nb_bus = unique_bus.shape[0]
@@ -1565,6 +1563,14 @@ class BaseObservation(GridObjects):
         If `bus_connectivity_matrix[i,j] = 1` then at least a power line connects bus i and bus j.
         Otherwise, nothing connects it.
 
+        .. warning::
+            The matrix returned by this function has not a fixed size. Its
+            number of nodes and edges can change depending on the state of the grid.
+            See :ref:`get-the-graph-gridgraph` for more information.
+            
+            Also, note that when "done=True" this matrix has size (1, 1)
+            and contains only 0.
+            
         Parameters
         ----------
         as_csr_matrix: ``bool``
@@ -1679,10 +1685,7 @@ class BaseObservation(GridObjects):
         """
         bus_id = 1 * self.topo_vect[id_topo_vect]
         connected = bus_id > 0
-        # bus_id[connected] = sub_id[connected] + (bus_id[connected] - 1) * self.n_sub
-        bus_id[connected] += sub_id[connected] + (bus_id[connected] - 1) * self.n_sub
-        bus_id -= 1  # because its label 1-2 and not 0-1
-        bus_id[~connected] = -1
+        bus_id[connected] = sub_id[connected] + (bus_id[connected] - 1) * self.n_sub
         return bus_id, connected
 
     def flow_bus_matrix(self, active_flow=True, as_csr_matrix=False):
@@ -1696,6 +1699,14 @@ class BaseObservation(GridObjects):
         The other  element of each **row** of this matrix will be the flow of power from the bus represented
         by the line i to the bus represented by column j.
 
+        .. warning::
+            The matrix returned by this function has not a fixed size. Its
+            number of nodes and edges can change depending on the state of the grid.
+            See :ref:`get-the-graph-gridgraph` for more information.
+            
+            Also, note that when "done=True" this matrix has size (1, 1)
+            and contains only 0.
+            
         Notes
         ------
         When the observation is in a "done" state (*eg* there has been a game over) then this function returns a 
@@ -1971,6 +1982,14 @@ class BaseObservation(GridObjects):
             injected at node 6 from this edge will be *p_or*) and the "extremity" side is bus 8
             (**eg** the active power injected at node 8 from this edge will be *p_ex*).
 
+        .. warning::
+            The graph returned by this function has not a fixed size. Its
+            number of nodes and edges can change depending on the state of the grid.
+            See :ref:`get-the-graph-gridgraph` for more information.
+            
+            Also, note that when "done=True" this graph has only one node and
+            no edge.
+            
         .. note::
             The graph returned by this function is "frozen" to prevent its modification. If you really want to modify
             it you can "unfroze" it.

--- a/grid2op/Reward/L2RPNSandBoxScore.py
+++ b/grid2op/Reward/L2RPNSandBoxScore.py
@@ -32,6 +32,7 @@ class L2RPNSandBoxScore(BaseReward):
                  alpha_redisp=1.0,
                  alpha_loss=1.0,
                  alpha_storage=1.0,
+                 alpha_curtailment=1.0,
                  reward_max=1000.,
                  logger=None):
         BaseReward.__init__(self, logger=logger)
@@ -40,6 +41,7 @@ class L2RPNSandBoxScore(BaseReward):
         self.alpha_redisp = dt_float(alpha_redisp)
         self.alpha_loss = dt_float(alpha_loss)
         self.alpha_storage = dt_float(alpha_storage)
+        self.alpha_curtailment = dt_float(alpha_curtailment)
 
     def initialize(self, env):
         # TODO compute reward max! 
@@ -65,9 +67,16 @@ class L2RPNSandBoxScore(BaseReward):
     def _get_redisp_cost(self, env, p_t):
         actual_dispatch = env._actual_dispatch
         c_redispatching = (
-            dt_float(2.0) * np.sum(np.abs(actual_dispatch)) * p_t * env.delta_time_seconds / 3600.0
+            np.sum(np.abs(actual_dispatch)) * p_t * env.delta_time_seconds / 3600.0
         )
         return c_redispatching
+    
+    def _get_curtail_cost(self, env, p_t):
+        curtailment_mw = -env._sum_curtailment_mw  # curtailment is always negative in the env 
+        c_curtailment = (
+            curtailment_mw * p_t * env.delta_time_seconds / 3600.0
+        )
+        return c_curtailment
 
     def _get_loss_cost(self, env, p_t):
         gen_p = self._get_gen_p(env)
@@ -91,6 +100,9 @@ class L2RPNSandBoxScore(BaseReward):
         # redispatching amount
         c_redispatching = self._get_redisp_cost(env, p_t)
         
+        # curtailment amount
+        c_curtailment = self._get_curtail_cost(env, p_t)
+        
         # cost of losses
         c_loss = self._get_loss_cost(env, p_t)
         
@@ -98,6 +110,8 @@ class L2RPNSandBoxScore(BaseReward):
         c_storage = self._get_storage_cost(env, p_t)
         
         # total "operationnal cost"
-        c_operations = dt_float(self.alpha_loss * c_loss + self.alpha_redisp * c_redispatching + self.alpha_storage * c_storage)
-
+        c_operations = dt_float(self.alpha_loss * c_loss + 
+                                self.alpha_redisp * c_redispatching + 
+                                self.alpha_storage * c_storage + 
+                                self.alpha_curtailment * c_curtailment)
         return c_operations

--- a/grid2op/Reward/l2rpn_wcci2022_scorefun.py
+++ b/grid2op/Reward/l2rpn_wcci2022_scorefun.py
@@ -31,9 +31,10 @@ class L2RPNWCCI2022ScoreFun(L2RPNSandBoxScore):
                  alpha_redisp=1.0,
                  alpha_loss=1.0,
                  alpha_storage=1.0,
+                 alpha_curtailment=1.0,
                  reward_max=1000.,
                  logger=None):
-        super().__init__(alpha_redisp, alpha_loss, alpha_storage, reward_max, logger)
+        super().__init__(alpha_redisp, alpha_loss, alpha_storage, alpha_curtailment, reward_max, logger)
         self.storage_cost = dt_float(storage_cost)
         
     def _get_storage_cost(self, env, p_t):

--- a/grid2op/__init__.py
+++ b/grid2op/__init__.py
@@ -11,7 +11,7 @@
 Grid2Op
 
 """
-__version__ = '1.7.1'
+__version__ = '1.7.2.rc1'
 
 __all__ = [
     "Action",

--- a/grid2op/__init__.py
+++ b/grid2op/__init__.py
@@ -11,7 +11,7 @@
 Grid2Op
 
 """
-__version__ = '1.7.2.rc1'
+__version__ = '1.7.2.rc2'
 
 __all__ = [
     "Action",

--- a/grid2op/tests/test_MultiMix.py
+++ b/grid2op/tests/test_MultiMix.py
@@ -26,12 +26,12 @@ warnings.simplefilter("error")
 
 class TestMultiMixEnvironment(unittest.TestCase):
     def test_creation(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         assert mme.current_obs is not None
         assert mme.current_env is not None
 
     def test_get_path_env(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         path_mme = mme.get_path_env()
         for mix in mme:
             path_mix = mix.get_path_env()
@@ -49,7 +49,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
     def test_creation_with_params(self):
         p = Parameters()
         p.MAX_SUB_CHANGED = 666
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p, _test=True)
         assert mme.current_obs is not None
         assert mme.current_env is not None
         assert mme.parameters.MAX_SUB_CHANGED == 666
@@ -61,7 +61,8 @@ class TestMultiMixEnvironment(unittest.TestCase):
             "game": GameplayReward,
             "l2rpn": L2RPNReward,
         }
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p, other_rewards=oth_r)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p, 
+                                  other_rewards=oth_r, _test=True)
         assert mme.current_obs is not None
         assert mme.current_env is not None
         o, r, d, i = mme.step(mme.action_space({}))
@@ -75,7 +76,9 @@ class TestMultiMixEnvironment(unittest.TestCase):
             def dummy(self):
                 return True
 
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, backend=DummyBackend1())
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, 
+                                  backend=DummyBackend1(), 
+                                  _test=True)
         assert mme.current_obs is not None
         assert mme.current_env is not None
         for env in mme:
@@ -83,9 +86,17 @@ class TestMultiMixEnvironment(unittest.TestCase):
 
     def test_creation_with_backend_are_not_shared(self):
         class DummyBackend2(PandaPowerBackend):
-            def __init__(self, detailed_infos_for_cascading_failures=False):
+            def __init__(self, detailed_infos_for_cascading_failures=False,
+                         can_be_copied=True,
+                         ligthsim2grid=False,
+                         dist_slack=False,
+                         max_iter=10):
                 super().__init__(
-                    detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures
+                    detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures,
+                    can_be_copied=can_be_copied,
+                    ligthsim2grid=ligthsim2grid,
+                    dist_slack=dist_slack,
+                    max_iter=max_iter
                 )
                 self.calls = 0
 
@@ -94,7 +105,9 @@ class TestMultiMixEnvironment(unittest.TestCase):
                 self.calls += 1
                 return r
 
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, backend=DummyBackend2())
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX,
+                                  backend=DummyBackend2(),
+                                  _test=True)
         assert mme.current_obs is not None
         assert mme.current_env is not None
         for t in range(3):
@@ -108,6 +121,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
             opponent_class=BaseOpponent,
             opponent_init_budget=42.0,
             opponent_budget_per_ts=0.42,
+            _test=True
         )
         assert mme.current_obs is not None
         assert mme.current_env is not None
@@ -117,7 +131,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
             assert env._opponent_budget_per_ts == dt_float(0.42)
 
     def test_reset(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         mme.reset()
         assert mme.current_obs is not None
         assert mme.current_env is not None
@@ -125,7 +139,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
     def test_reset_with_params(self):
         p = Parameters()
         p.MAX_SUB_CHANGED = 666
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p, _test=True)
         mme.reset()
         assert mme.current_obs is not None
         assert mme.current_env is not None
@@ -138,7 +152,8 @@ class TestMultiMixEnvironment(unittest.TestCase):
             "game": GameplayReward,
             "l2rpn": L2RPNReward,
         }
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p, other_rewards=oth_r)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, param=p,
+                                  other_rewards=oth_r, _test=True)
         mme.reset()
 
         assert mme.current_obs is not None
@@ -151,9 +166,19 @@ class TestMultiMixEnvironment(unittest.TestCase):
 
     def test_reset_with_backend(self):
         class DummyBackend3(PandaPowerBackend):
-            def __init__(self, detailed_infos_for_cascading_failures=False):
+            def __init__(self, 
+                         detailed_infos_for_cascading_failures=False,
+                         can_be_copied=True,
+                         ligthsim2grid=False,
+                         dist_slack=False,
+                         max_iter=10
+                         ):
                 super().__init__(
-                    detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures
+                    detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures,
+                    can_be_copied=can_be_copied,
+                    ligthsim2grid=ligthsim2grid,
+                    dist_slack=dist_slack,
+                    max_iter=max_iter
                 )
                 self._dummy = -1
 
@@ -163,7 +188,9 @@ class TestMultiMixEnvironment(unittest.TestCase):
             def dummy(self):
                 return self._dummy
 
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, backend=DummyBackend3())
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX,
+                                  backend=DummyBackend3(),
+                                  _test=True)
         mme.reset()
         assert mme.current_env.backend.dummy() == 1
 
@@ -172,7 +199,8 @@ class TestMultiMixEnvironment(unittest.TestCase):
             PATH_DATA_MULTIMIX,
             opponent_class=BaseOpponent,
             opponent_init_budget=42.0,
-            opponent_budget_per_ts=0.42,
+            opponent_budget_per_ts=0.42, 
+            _test=True,
         )
         mme.reset()
         assert mme.current_obs is not None
@@ -182,7 +210,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert mme._opponent_budget_per_ts == dt_float(0.42)
 
     def test_reset_seq(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         for i in range(2):
             assert i == mme.current_index
             mme.reset()
@@ -190,22 +218,22 @@ class TestMultiMixEnvironment(unittest.TestCase):
             assert mme.current_env is not None
 
     def test_reset_random(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         for i in range(2):
             mme.reset(random=True)
             assert mme.current_obs is not None
             assert mme.current_env is not None
 
     def test_seeding(self):
-        mme1 = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme1 = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         seeds_1 = mme1.seed(2)
         mme1.close()
 
-        mme2 = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme2 = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         seeds_2 = mme2.seed(42)
         mme2.close()
 
-        mme3 = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme3 = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         seeds_3 = mme3.seed(2)
         mme3.close()
 
@@ -213,7 +241,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert np.any(seeds_1 != seeds_2)
 
     def test_step_dn(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         dn = mme.action_space({})
 
         obs, r, done, info = mme.step(dn)
@@ -224,7 +252,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
 
     def test_step_switch_line(self):
         LINE_ID = 4
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         line_ex_topo = mme.line_ex_pos_topo_vect[LINE_ID]
         line_or_topo = mme.line_or_pos_topo_vect[LINE_ID]
         switch_status = mme.action_space.get_change_line_status_vect()
@@ -240,7 +268,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert obs.line_status[LINE_ID] == True, "Line is not reconnected"
 
     def test_forecast_toggle(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         dn = mme.action_space({})
         # Forecast off
         mme.deactivate_forecast()
@@ -262,7 +290,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
         assert done is not True
 
     def test_bracket_access_by_name(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
 
         mix1_env = mme["case14_001"]
         assert mix1_env.name == "case14_001"
@@ -272,7 +300,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
             unknown_env = mme["unknown_raise"]
 
     def test_keys_access(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
 
         for k in mme.keys():
             mix = mme[k]
@@ -281,7 +309,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
             assert mix.name == k
 
     def test_values_access(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
 
         for v in mme.values():
             assert v is not None
@@ -289,14 +317,14 @@ class TestMultiMixEnvironment(unittest.TestCase):
             assert v == mme[v.name]
 
     def test_values_unique(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         vals = list(mme.values())
         vals_unique = list(set(vals))
 
         assert len(vals) == len(vals_unique)
 
     def test_items_acces(self):
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
 
         for k, v in mme.items():
             assert k is not None
@@ -306,7 +334,7 @@ class TestMultiMixEnvironment(unittest.TestCase):
 
     def test_copy(self):
         # https://github.com/BDonnot/lightsim2grid/issues/10
-        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX)
+        mme = MultiMixEnvironment(PATH_DATA_MULTIMIX, _test=True)
         for i in range(5):
             obs, reward, done, info = mme.step(mme.action_space())
         env2 = mme.copy()

--- a/grid2op/tests/test_act_as_serializable_dict.py
+++ b/grid2op/tests/test_act_as_serializable_dict.py
@@ -119,6 +119,7 @@ class TestActionSerialDict(unittest.TestCase):
     def tearDown(self):
         self.authorized_keys = {}
         self.gridobj._clear_class_attribute()
+        ActionSpace._clear_class_attribute()
 
     def setUp(self):
         """

--- a/grid2op/tests/test_educpp_backend.py
+++ b/grid2op/tests/test_educpp_backend.py
@@ -25,7 +25,8 @@ class EducPPTester(unittest.TestCase):
             if (env_name == "l2rpn_icaps_2021" or 
                 env_name == "l2rpn_neurips_2020_track1" or
                 env_name == "l2rpn_wcci_2020" or
-                env_name == "l2rpn_wcci_2022_dev" 
+                env_name == "l2rpn_wcci_2022_dev" or
+                env_name == "l2rpn_wcci_2022"
             ):
                 # does not work because of generators name
                 # in the redispatching data
@@ -34,9 +35,13 @@ class EducPPTester(unittest.TestCase):
             
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
-                env = grid2op.make(env_name, test=True, backend=EducPandaPowerBackend())
+                env = grid2op.make(env_name,
+                                   test=True,
+                                   backend=EducPandaPowerBackend(),
+                                   _add_to_name="educppbk")
                 assert type(env).n_shunt is None, f"error for {env_name}"
                 assert not type(env).shunts_data_available, f"error for {env_name}"
+            env.close()
             
             
 if __name__ == "__main__":

--- a/grid2op/tests/test_issue_321.py
+++ b/grid2op/tests/test_issue_321.py
@@ -29,7 +29,7 @@ class Issue321Tester(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make(env_name, test=True,
-                            action_class=PlayableAction, param=param)
+                               action_class=PlayableAction, param=param)
             
         env.seed(0)
         env.set_id(0)

--- a/grid2op/tests/test_issue_327.py
+++ b/grid2op/tests/test_issue_327.py
@@ -21,7 +21,7 @@ class Issue327Tester(unittest.TestCase):
     def setUp(self) -> None:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.env = grid2op.make("l2rpn_case14_sandbox")
+            self.env = grid2op.make("l2rpn_case14_sandbox", test=True)
         return super().setUp()
     
     def tearDown(self) -> None:

--- a/grid2op/tests/test_issue_331.py
+++ b/grid2op/tests/test_issue_331.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2019-2022, RTE (https://www.rte-france.com)
+# See AUTHORS.txt and https://github.com/rte-france/Grid2Op/pull/319
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import pdb
+import warnings
+import unittest
+import grid2op
+from grid2op.Exceptions import Grid2OpException
+
+
+class Issue331Tester(unittest.TestCase):
+    def test_seed(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = grid2op.make("l2rpn_case14_sandbox", test=True)
+            
+        with self.assertRaises(Grid2OpException):
+            env.seed(2735729614)  # crashes !
+            
+        env.seed(2147483647)  # just the limit
+        
+        with self.assertRaises(Grid2OpException):
+            env.seed(2147483648)  # crashes !
+
+
+if __name__ == "__main__":
+    unittest.main()
+    

--- a/grid2op/tests/test_issue_340.py
+++ b/grid2op/tests/test_issue_340.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2019-2022, RTE (https://www.rte-france.com)
+# See AUTHORS.txt and https://github.com/rte-france/Grid2Op/pull/319
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import pdb
+import warnings
+import unittest
+import grid2op
+from grid2op.Exceptions import Grid2OpException
+import numpy as np
+
+
+class Issue340Tester(unittest.TestCase):
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("l2rpn_wcci_2022", test=True)
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        self.env.close()
+        return super().tearDown()
+    
+    def test_obs(self):
+        obs = self.env.reset()
+        obs.state_of(storage_id=0)
+        
+    def test_act_add(self):
+        act0 = self.env.action_space({"curtail": [(0, 0.5)]})
+        act1 = self.env.action_space({"curtail": [(1, 0.5)]})
+        res = act0 + act1
+        assert np.all(res.curtail[[0,1]] == 0.5)
+  
+
+if __name__ == "__main__":
+    unittest.main()
+    

--- a/grid2op/tests/test_score_wcci_2022.py
+++ b/grid2op/tests/test_score_wcci_2022.py
@@ -16,8 +16,6 @@ from grid2op.Agent.doNothing import DoNothingAgent
 from grid2op.Reward import L2RPNWCCI2022ScoreFun
 from grid2op.utils import ScoreL2RPN2022
 
-import pdb
-
 
 class AgentTester(BaseAgent):
     def act(self, observation, reward, done):
@@ -29,6 +27,7 @@ class AgentTester(BaseAgent):
     
     
 class WCCI2022Tester(unittest.TestCase):
+    """tests are focused on the storage units for this class"""
     def setUp(self) -> None:
         self.seed = 0
         self.scen_id = 0
@@ -137,6 +136,71 @@ class WCCI2022Tester(unittest.TestCase):
             assert np.all(np.abs(np.array(res_agent[0]) - np.array([-0.07931602, -0.08532347])) <= 1e-6)
         finally:
             my_score.clear_all()
+
+class TestL2RPNWCCI2022ScoreFun(unittest.TestCase): 
+    """test curtailment and redispatching scores to make sure they match the description in the html of the competition.
+    
+    (storage are tested in the class just above, so i don't retest them here)
+    """
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("l2rpn_wcci_2022", test=True)
+        self.env.seed(0)
+        self.env.reset()
+        self.score_fun = L2RPNWCCI2022ScoreFun()
+        self.score_fun.initialize(self.env)   
+        
+        # run the env without actions
+        self.env.set_id(0)
+        obs = self.env.reset()
+        dn_ = self.env.action_space()
+        self.obs_ref, reward, done, info = self.env.step(dn_)
+        obs = self.obs_ref
+        self.score_ref = self.score_fun(env=self.env, action=dn_, is_done=False, has_error=False, is_illegal=False, is_ambiguous=False)
+        self.losses_ref = np.sum(obs.gen_p) - np.sum(obs.load_p)
+        self.pt_ref = obs.gen_cost_per_MW[obs.gen_p > 0].max()
+        
+        # test that the score, in this case, is the losses
+        assert np.abs(self.score_ref - self.losses_ref * self.pt_ref / 12.) <= 1e-4
+             
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        self.env.close()
+        return super().tearDown()
+    
+    def test_unary_curtailment(self):
+        gen_id = 0
+        # now apply a curtailment action and compute the score
+        for E_curt in [0.5, 1., 2., 3.]:
+            self.env.set_id(0)
+            obs = self.env.reset()
+            # curtail a certain amount of MWh and check the formula is correct
+            act = self.env.action_space({"curtail": [(gen_id,(self.obs_ref.gen_p[gen_id] - 12. * E_curt) / obs.gen_pmax[gen_id])]})
+            obs, reward, done, info = self.env.step(act)
+            assert not info['exception']
+            score = self.score_fun(env=self.env, action=act, is_done=False, has_error=False, is_illegal=False, is_ambiguous=False)
+            losses = np.sum(obs.gen_p) - np.sum(obs.load_p)
+            pt = obs.gen_cost_per_MW[obs.gen_p > 0].max()
+            assert np.abs(pt - self.pt_ref) <= 1e-5, f"wrong marginal price for {E_curt:.2f}"
+            assert np.abs(score - (losses * pt / 12. + 2 * E_curt * pt)) <= 1e-4, f"error for {E_curt:.2f}"
+        
+    def test_unary_redisp(self):
+        gen_id = 8  # ramps is 11.2
+        # now apply a redispatching action and compute the score
+        for E_redisp in [-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9]:
+            self.env.set_id(0)
+            obs = self.env.reset()
+            # curtail 12MW for 5 mins => 1 MWh (next step gen 0 should produce 41.6 MW)
+            act = self.env.action_space({"redispatch": [(gen_id, 12. * E_redisp)]})
+            obs, reward, done, info = self.env.step(act)
+            assert not info['exception'], f'one error occured for {E_redisp:.2f}'
+            score = self.score_fun(env=self.env, action=act, is_done=False, has_error=False, is_illegal=False, is_ambiguous=False)
+            losses = np.sum(obs.gen_p) - np.sum(obs.load_p)
+            pt = obs.gen_cost_per_MW[obs.gen_p > 0].max()
+            assert np.abs(pt - self.pt_ref) <= 1e-5, f"wrong marginal price for {E_redisp:.2f}"
+            assert np.abs(score - (losses * pt / 12. + 2 * np.abs(E_redisp) * pt)) <= 2e-4, f"error for {E_redisp:.2f}"
         
         
 if __name__ == "__main__":

--- a/utils/make_release.py
+++ b/utils/make_release.py
@@ -73,6 +73,9 @@ if __name__ == "__main__":
             "Please modify \"--version\" argument")
 
     regex_version = "[0-9]+\.[0-9]+\.[0-9]+(.post[0-9]+){0,1}(.rc[0-9]+){0,1}(.pre[0-9]+){0,1}"
+    # TODO use the official regex !
+    # see https://semver.org/ and https://regex101.com/r/Ly7O1x/3/
+    # regex_version = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
     regex_version_with_str = f"['\"]{regex_version}['\"]"
     if re.match("^{}$".format(regex_version), version) is None:
         raise RuntimeError(
@@ -80,6 +83,7 @@ if __name__ == "__main__":
             "Please modify \"--version\" argument".format(
                 version))
 
+    # TODO re.search(reg_, "0.0.4-rc1").group("prerelease") -> rc1 (if regex_version is the official one)
     if re.search(f".*\.(rc|pre)[0-9]+$", version) is not None:
         is_prerelease = True
         print("This is a pre release, docker will NOT be pushed, github tag will NOT be made")


### PR DESCRIPTION
- [FIXED] seeding issue https://github.com/rte-france/Grid2Op/issues/331
- [FIXED] clarify doc about fixed size matrices / graphs https://github.com/rte-france/Grid2Op/issues/330
- [FIXED] improved the behaviour of `obs._get_bus_id` and `obs._aux_fun_get_bus` : when some objects were on busbar 2
  they had a "wrong" bus id (it was lagged by 1) meaning an empty "bus" was introduced.
- [FIXED] an issue with `obs.state_of(...)` when inspecting storage units 
  (see https://github.com/rte-france/Grid2Op/issues/340)
- [FIXED] an issue with `act0 + act1` when curtailment was applied 
  (see https://github.com/rte-france/Grid2Op/issues/340)
- [FIXED] a slight "bug" in the formula to compute the redispatching cost for L2RPN 2022 competition.
- [IMPROVED] possibility to pass the env variable `_GRID2OP_FORCE_TEST` to force the flag
   of "test=True" when creating an environment. This is especially useful when testing to prevent
   downloading of data.
- [IMPROVED] support of "kwargs" backend arguments in `MultiMixEnv` see first
  item of version 1.7.1 below