### PR TITLE
Dev 1.8.1 - added save/load methods to baseAgent class from Rosalie project

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,11 @@ Change Log
 - [???] "asynch" multienv
 - [???] properly model interconnecting powerlines
 
+[1.8.1] - 2023-xx-yy
+-------------------------
+- [ADDED] the baseAgent class now has two new template methods `save_state` and `load_state` to save and
+  load the agent's state during Grid2op simulations. Examples can be found in L2RPN baselines (PandapowerOPFAgent and curriculumagent).
+
 [1.8.0] - 2022-12-yy
 --------------------
 - [BREAKING] now requires numpy >= 1.20 to work (otherwise there are 
@@ -62,8 +67,6 @@ Change Log
   numpy pseudo random generator.
 - [ADDED] the function `act.remove_line_status_from_topo` to ignore the line status modification
   that would be induced by "set_bus" or "change_bus" when some cooldown applies on the powerline.
-- [ADDED] the baseAgent class now has two new template methods `save_state` and `load_state` to save and
-  load the agent's state during Grid2op simulations. Examples can be found in L2RPN baselines (PandapowerOPFAgent and curriculumagent).
 - [IMPROVED] clarify documentation of gym compat module (see 
   https://github.com/rte-france/Grid2Op/issues/372 and 
   https://github.com/rte-france/Grid2Op/issues/373) as well as the doc

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,8 @@ Change Log
   numpy pseudo random generator.
 - [ADDED] the function `act.remove_line_status_from_topo` to ignore the line status modification
   that would be induced by "set_bus" or "change_bus" when some cooldown applies on the powerline.
+- [ADDED] the baseAgent class now has two new template methods `save_state` and `load_state` to save and
+  load the agent's state during Grid2op simulations. Examples can be found in L2RPN baselines (PandapowerOPFAgent and curriculumagent).
 - [IMPROVED] clarify documentation of gym compat module (see 
   https://github.com/rte-france/Grid2Op/issues/372 and 
   https://github.com/rte-france/Grid2Op/issues/373) as well as the doc

--- a/grid2op/Agent/baseAgent.py
+++ b/grid2op/Agent/baseAgent.py
@@ -7,7 +7,7 @@
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
 import copy
-
+import os
 from abc import ABC, abstractmethod
 from grid2op.Space import RandomObject
 
@@ -109,5 +109,66 @@ class BaseAgent(RandomObject, ABC):
         res: :class:`grid2op.Action.PlaybleAction`
             The action chosen by the bot / controler / agent.
 
+        """
+        pass
+
+
+    def save_state(self, savestate_path :os.PathLike):  
+        """
+        An optional method to save the internal state of your agent.
+        The saved state can later be re-loaded with `self.load_state`, e.g. to repeat 
+        a Grid2Op time step with exactly the same internal parameterization. This
+        can be useful to repeat Grid2Op experiments and analyze why your agent performed 
+        certain actions in past time steps. Concept developed by Fraunhofer IEE KES.
+
+        Notes
+        -----
+        First, the internal state your agent consists of attributes that are contained in 
+        the :class:`grid2op.Agent.BaseAgent` and :class:`grid2op.Agent.BaseAgent.action_space`.
+        Examples are the parameterization and seeds of the random number generator that your
+        agent uses. Such attributes can easily be obtained with the :func:`getattr` and stored
+        in a common file format, such as `.npy`.
+        
+        Second, your agent may contain custom attributes, such as e.g. a vector of line indices 
+        from a Grid2Op observation. You could obtain and save them in the same way as explained 
+        before.
+
+        Third, your agent may contain very specific modules such as `Tensorflow` that
+        do not support the simple :func:`getattr`. However, these modules normally have
+        their own methods to save an internal state. Examples of such methods are
+        :func:`save_weights` that you can integrate in your implementation of `self.save_state`.
+        
+        Parameters
+        ----------
+        savestate_path: ``string``
+            The path to which your agent state variables should be saved
+        """
+        pass
+    
+    
+    def load_state(self, loadstate_path :os.PathLike):  
+        """
+        An optional method to re-load the internal agent state that was saved with `self.save_state`. 
+        This can be useful to re-set your agent to an earlier simulation time step and reproduce 
+        past experiments with Grid2Op. Concept developed by Fraunhofer IEE KES.
+
+        Notes
+        -----
+        First, the internal state your agent consists of attributes that are contained in 
+        the :class:`grid2op.Agent.BaseAgent` and :class:`grid2op.Agent.BaseAgent.action_space`.
+        Such attributes can easily be re-set with :func:`setattr`.
+        
+        Second, your agent may contain custom attributes, such as e.g. a vector of line indices 
+        from a Grid2Op observation. You can re-set them with :func:`setattr` as well.
+
+        Third, your agent may contain very specific modules such as `Tensorflow` that
+        do not support the simple :func:`setattr`. However, these modules normally have
+        their own methods to re-load an internal state. Examples of such methods are
+        :func:`load_weights` that you can integrate in your implementation of `self.load_state`.
+        
+        Parameters
+        ----------
+        savestate_path: ``string``
+            The path from which your agent state variables should be loaded
         """
         pass

--- a/grid2op/Agent/baseAgent.py
+++ b/grid2op/Agent/baseAgent.py
@@ -112,7 +112,6 @@ class BaseAgent(RandomObject, ABC):
         """
         pass
 
-
     def save_state(self, savestate_path :os.PathLike):  
         """
         An optional method to save the internal state of your agent.
@@ -144,7 +143,6 @@ class BaseAgent(RandomObject, ABC):
             The path to which your agent state variables should be saved
         """
         pass
-    
     
     def load_state(self, loadstate_path :os.PathLike):  
         """


### PR DESCRIPTION
We added a save/load method template to the baseAgent class, as optional methods that can be used to save and load the agent state during Grid2op simulations (during hand-written time loops or after completion of a runner execution). Examples will be provied in L2RPN baselines Git.