### PR TITLE
Update to version 1.8.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,13 +31,16 @@ Change Log
 - [???] "asynch" multienv
 - [???] properly model interconnecting powerlines
 
-[1.8.1] - 2023-xx-yy
--------------------------
+[1.8.1] - 2023-01-11
+---------------------
+- [FIXED] a deprecation with numpy>= 1.24 (**eg** np.bool and np.str)
 - [ADDED] the baseAgent class now has two new template methods `save_state` and `load_state` to save and
   load the agent's state during Grid2op simulations. Examples can be found in L2RPN baselines (PandapowerOPFAgent and curriculumagent).
+- [IMPROVED] error message in pandapower backend when the grid do not converge due to disconnected
+   generators or loads.
 
-[1.8.0] - 2022-12-yy
---------------------
+[1.8.0] - 2022-12-12
+---------------------
 - [BREAKING] now requires numpy >= 1.20 to work (otherwise there are 
   issues with newer versions of pandas).
 - [BREAKING] issue https://github.com/rte-france/Grid2Op/issues/379 requires

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,11 @@ Change Log
 - [???] "asynch" multienv
 - [???] properly model interconnecting powerlines
 
+[1.8.1] - 2023-xx-yy
+-------------------------
+- [ADDED] the baseAgent class now has two new template methods `save_state` and `load_state` to save and
+  load the agent's state during Grid2op simulations. Examples can be found in L2RPN baselines (PandapowerOPFAgent and curriculumagent).
+
 [1.8.0] - 2022-12-yy
 --------------------
 - [BREAKING] now requires numpy >= 1.20 to work (otherwise there are 

--- a/grid2op/Agent/baseAgent.py
+++ b/grid2op/Agent/baseAgent.py
@@ -7,7 +7,7 @@
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
 import copy
-
+import os
 from abc import ABC, abstractmethod
 from grid2op.Space import RandomObject
 
@@ -109,5 +109,64 @@ class BaseAgent(RandomObject, ABC):
         res: :class:`grid2op.Action.PlaybleAction`
             The action chosen by the bot / controler / agent.
 
+        """
+        pass
+
+    def save_state(self, savestate_path :os.PathLike):  
+        """
+        An optional method to save the internal state of your agent.
+        The saved state can later be re-loaded with `self.load_state`, e.g. to repeat 
+        a Grid2Op time step with exactly the same internal parameterization. This
+        can be useful to repeat Grid2Op experiments and analyze why your agent performed 
+        certain actions in past time steps. Concept developed by Fraunhofer IEE KES.
+
+        Notes
+        -----
+        First, the internal state your agent consists of attributes that are contained in 
+        the :class:`grid2op.Agent.BaseAgent` and :class:`grid2op.Agent.BaseAgent.action_space`.
+        Examples are the parameterization and seeds of the random number generator that your
+        agent uses. Such attributes can easily be obtained with the :func:`getattr` and stored
+        in a common file format, such as `.npy`.
+        
+        Second, your agent may contain custom attributes, such as e.g. a vector of line indices 
+        from a Grid2Op observation. You could obtain and save them in the same way as explained 
+        before.
+
+        Third, your agent may contain very specific modules such as `Tensorflow` that
+        do not support the simple :func:`getattr`. However, these modules normally have
+        their own methods to save an internal state. Examples of such methods are
+        :func:`save_weights` that you can integrate in your implementation of `self.save_state`.
+        
+        Parameters
+        ----------
+        savestate_path: ``string``
+            The path to which your agent state variables should be saved
+        """
+        pass
+    
+    def load_state(self, loadstate_path :os.PathLike):  
+        """
+        An optional method to re-load the internal agent state that was saved with `self.save_state`. 
+        This can be useful to re-set your agent to an earlier simulation time step and reproduce 
+        past experiments with Grid2Op. Concept developed by Fraunhofer IEE KES.
+
+        Notes
+        -----
+        First, the internal state your agent consists of attributes that are contained in 
+        the :class:`grid2op.Agent.BaseAgent` and :class:`grid2op.Agent.BaseAgent.action_space`.
+        Such attributes can easily be re-set with :func:`setattr`.
+        
+        Second, your agent may contain custom attributes, such as e.g. a vector of line indices 
+        from a Grid2Op observation. You can re-set them with :func:`setattr` as well.
+
+        Third, your agent may contain very specific modules such as `Tensorflow` that
+        do not support the simple :func:`setattr`. However, these modules normally have
+        their own methods to re-load an internal state. Examples of such methods are
+        :func:`load_weights` that you can integrate in your implementation of `self.load_state`.
+        
+        Parameters
+        ----------
+        savestate_path: ``string``
+            The path from which your agent state variables should be loaded
         """
         pass

--- a/grid2op/Chronics/Settings_L2RPN2019.py
+++ b/grid2op/Chronics/Settings_L2RPN2019.py
@@ -264,11 +264,11 @@ class L2RPN2019_Action(BaseAction):
         next_ = self.n_line
 
         self._switch_line_status = vect[prev_:next_]
-        self._switch_line_status = self._switch_line_status.astype(np.bool)
+        self._switch_line_status = self._switch_line_status.astype(np.bool_)
         prev_ = next_
         next_ += self.dim_topo
         self._change_bus_vect = vect[prev_:next_]
-        self._change_bus_vect = self._change_bus_vect.astype(np.bool)
+        self._change_bus_vect = self._change_bus_vect.astype(np.bool_)
 
         # self.disambiguate_reconnection()
 

--- a/grid2op/Space/GridObjects.py
+++ b/grid2op/Space/GridObjects.py
@@ -2264,7 +2264,7 @@ class GridObjects:
         if not isinstance(cls.name_shunt, np.ndarray):
             try:
                 cls.name_shunt = np.array(cls.name_shunt)
-                cls.name_shunt = cls.name_shunt.astype(np.str)
+                cls.name_shunt = cls.name_shunt.astype(np.str_)
             except Exception as exc:
                 raise EnvError(
                     'name_shunt should be convertible to a numpy array with dtype "str".'

--- a/grid2op/dtypes.py
+++ b/grid2op/dtypes.py
@@ -13,4 +13,5 @@ dt_int = (
 dt_float = (
     np.float32
 )  # dtype('float64') or dtype('float32') depending on platform  => i force it to float32
-dt_bool = np.bool
+
+dt_bool = np.bool_  # mandatory for numpy >= 1.24

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,11 @@ keywords = ML powergrid optmization RL power-systems
 license = Mozilla Public License 2.0 (MPL 2.0)
 classifiers = 
     Development Status :: 4 - Beta
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     Intended Audience :: Developers
     Intended Audience :: Education


### PR DESCRIPTION
Fixed issues
------------------
- a deprecation with numpy>= 1.24 (**eg** `np.bool` and `np.str`), related to #393 

Additions
--------------
- the baseAgent class now has two new template methods `save_state` and `load_state` to save and
  load the agent's state during Grid2op simulations. Examples can be found in L2RPN baselines (PandapowerOPFAgent and curriculumagent).

Improvments
-------------------
- improved error messages in pandapower backend when the grid do not converge due to disconnected generators or loads.
