### PR TITLE
dev_1.8.2  : add default rules to be set by area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ var/
 *.egg
 
 # VirtualEnv
-venv_grid2op/
+*venv_grid2op/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/grid2op/Rules/RulesByArea.py
+++ b/grid2op/Rules/RulesByArea.py
@@ -32,18 +32,23 @@ class RulesByArea(BaseRules):
         """
         See :func:`BaseRules.__call__` for a definition of the _parameters of this function.
         """
-        self.lines_id_by_area = {key : sorted(list(chain(*[[item for item in np.where(env.line_or_to_subid == subid)[0]
-                                   ] for subid in subid_list]))) for key,subid_list in self.substations_id_by_area.items()}
+        n_sub = env.n_sub
+        n_sub_rule = np.sum([len(set(list_ids)) for list_ids in self.substations_id_by_area.values()])
+        if n_sub_rule != n_sub: 
+            print("The number of listed ids of substations in rule initialization does not match the number of substations of the chosen environement. Look for missing ids or doublon")
+        else:
+            self.lines_id_by_area = {key : sorted(list(chain(*[[item for item in np.where(env.line_or_to_subid == subid)[0]
+                                    ] for subid in subid_list]))) for key,subid_list in self.substations_id_by_area.items()}
 
-        is_legal, reason = PreventDiscoStorageModif.__call__(self, action, env)
-        if not is_legal:
-            return False, reason
-        
-        is_legal, reason = self.LookParamByArea(action, env)
-        if not is_legal:
-            return False, reason
-        
-        return PreventReconnection.__call__(self, action, env)
+            is_legal, reason = PreventDiscoStorageModif.__call__(self, action, env)
+            if not is_legal:
+                return False, reason
+            
+            is_legal, reason = self.LookParamByArea(action, env)
+            if not is_legal:
+                return False, reason
+            
+            return PreventReconnection.__call__(self, action, env)
         
 
     def can_use_simulate(self, nb_simulate_call_step, nb_simulate_call_episode, param):

--- a/grid2op/Rules/RulesByArea.py
+++ b/grid2op/Rules/RulesByArea.py
@@ -1,0 +1,80 @@
+import numpy as np
+from itertools import chain
+from grid2op.Rules.BaseRules import BaseRules
+from grid2op.Rules.LookParam import LookParam
+from grid2op.Rules.PreventReconnection import PreventReconnection
+from grid2op.Rules.PreventDiscoStorageModif import PreventDiscoStorageModif
+from grid2op.Exceptions import (
+    IllegalAction,
+)
+
+class RulesByArea(BaseRules):
+    """
+    This subclass combine both :class:`LookParam` and :class:`PreventReconnection` to be applied on defined areas of a grid.
+    An action is declared legal if and only if:
+
+      - It doesn't disconnect / reconnect more power lines within each area than  what stated in the actual game _parameters
+        :class:`grid2op.Parameters`
+      - It doesn't attempt to act on more substations within each area that what is stated in the actual game _parameters
+        :class:`grid2op.Parameters`
+      - It doesn't attempt to modify the power produce by a turned off storage unit
+
+    """
+
+    def __init__(self, areas_list):
+        """
+        areas_list : list of areas, each placeholder containing the ids of substations of each defined area
+        """
+        self.substations_id_by_area = {i : sorted(k) for i,k in enumerate(areas_list)}
+
+
+    def __call__(self, action, env):
+        """
+        See :func:`BaseRules.__call__` for a definition of the _parameters of this function.
+        """
+        self.lines_id_by_area = {key : sorted(list(chain(*[[item for item in np.where(env.line_or_to_subid == subid)[0]
+                                   ] for subid in subid_list]))) for key,subid_list in self.substations_id_by_area.items()}
+
+        is_legal, reason = PreventDiscoStorageModif.__call__(self, action, env)
+        if not is_legal:
+            return False, reason
+        
+        is_legal, reason = self.LookParamByArea(action, env)
+        if not is_legal:
+            return False, reason
+        
+        return PreventReconnection.__call__(self, action, env)
+        
+
+    def can_use_simulate(self, nb_simulate_call_step, nb_simulate_call_episode, param):
+        return LookParam.can_use_simulate(
+            self, nb_simulate_call_step, nb_simulate_call_episode, param
+        )
+    
+    def LookParamByArea(self, action, env):
+        """
+        See :func:`BaseRules.__call__` for a definition of the parameters of this function.
+        """
+        # at first iteration, env.current_obs is None...
+        powerline_status = env.get_current_line_status()
+
+        aff_lines, aff_subs = action.get_topological_impact(powerline_status)
+        if any([np.sum(aff_lines[line_ids]) > env._parameters.MAX_LINE_STATUS_CHANGED for line_ids in self.lines_id_by_area.values()]):
+            ids = [[k for k in np.where(aff_lines)[0] if k in line_ids] for line_ids in self.lines_id_by_area.values()]
+            print(ids)
+            return False, IllegalAction(
+                "More than {} line status affected by the action in one area: {}"
+                "".format(env.parameters.MAX_LINE_STATUS_CHANGED, ids)
+            )
+        if any([np.sum(aff_subs[sub_ids]) > env._parameters.MAX_SUB_CHANGED for sub_ids in self.substations_id_by_area.values()]):
+            ids = [[k for k in np.where(aff_subs)[0] if k in sub_ids] for sub_ids in self.substations_id_by_area.values()]
+            print(ids)
+            return False, IllegalAction(
+                "More than {} substation affected by the action in one area: {}"
+                "".format(env.parameters.MAX_SUB_CHANGED, ids)
+            )
+        return True, None
+
+
+
+ 

--- a/grid2op/Rules/RulesByArea.py
+++ b/grid2op/Rules/RulesByArea.py
@@ -61,14 +61,12 @@ class RulesByArea(BaseRules):
         aff_lines, aff_subs = action.get_topological_impact(powerline_status)
         if any([np.sum(aff_lines[line_ids]) > env._parameters.MAX_LINE_STATUS_CHANGED for line_ids in self.lines_id_by_area.values()]):
             ids = [[k for k in np.where(aff_lines)[0] if k in line_ids] for line_ids in self.lines_id_by_area.values()]
-            print(ids)
             return False, IllegalAction(
                 "More than {} line status affected by the action in one area: {}"
                 "".format(env.parameters.MAX_LINE_STATUS_CHANGED, ids)
             )
         if any([np.sum(aff_subs[sub_ids]) > env._parameters.MAX_SUB_CHANGED for sub_ids in self.substations_id_by_area.values()]):
             ids = [[k for k in np.where(aff_subs)[0] if k in sub_ids] for sub_ids in self.substations_id_by_area.values()]
-            print(ids)
             return False, IllegalAction(
                 "More than {} substation affected by the action in one area: {}"
                 "".format(env.parameters.MAX_SUB_CHANGED, ids)

--- a/grid2op/tests/test_RulesByArea
+++ b/grid2op/tests/test_RulesByArea
@@ -1,17 +1,20 @@
+# Copyright (c) 2023, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
 import warnings
 from itertools import chain
 from grid2op.tests.helper_path_test import *
 from grid2op.Exceptions import *
-from grid2op.Environment import Environment
-from grid2op.Backend import PandaPowerBackend
 from grid2op.Parameters import Parameters
-from grid2op.Chronics import ChronicsHandler, GridStateFromFile
 from grid2op.Rules.RulesByArea import *
 from grid2op.MakeEnv import make
 
 import warnings
-
-warnings.simplefilter("error")
 
 class TestDefaultRulesByArea(unittest.TestCase):
     def setUp(self):
@@ -36,7 +39,7 @@ class TestDefaultRulesByArea(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             for rules in [self.rules_1area, self.rules_2areas, self.rules_3areas]:
-                env_ref = make(
+                self.env = make(
                         "l2rpn_case14_sandbox",
                         test=True,
                         param=params,
@@ -118,6 +121,7 @@ class TestDefaultRulesByArea(unittest.TestCase):
                         env=self.env,
                         check_legal=True,
                 )
+                self.env.close()
 
 
 if __name__ == "__main__":

--- a/grid2op/tests/test_RulesByArea
+++ b/grid2op/tests/test_RulesByArea
@@ -1,0 +1,124 @@
+import warnings
+from itertools import chain
+from grid2op.tests.helper_path_test import *
+from grid2op.Exceptions import *
+from grid2op.Environment import Environment
+from grid2op.Backend import PandaPowerBackend
+from grid2op.Parameters import Parameters
+from grid2op.Chronics import ChronicsHandler, GridStateFromFile
+from grid2op.Rules.RulesByArea import *
+from grid2op.MakeEnv import make
+
+import warnings
+
+warnings.simplefilter("error")
+
+class TestDefaultRulesByArea(unittest.TestCase):
+    def setUp(self):
+        params = Parameters()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env_ref = make(
+                "l2rpn_case14_sandbox",
+                test=True,
+                param=params,
+            )
+
+            self.substation_ids = [k for k in range(env_ref.n_sub)]
+            env_ref.close()
+
+            self.rules_1area = RulesByArea([[self.substation_ids]])
+            self.rules_2areas = RulesByArea([[k for k in list_ids] for list_ids in np.array_split(np.random.shuffle(self.substation_ids), 2)])
+            self.rules_3areas = RulesByArea([[k for k in list_ids] for list_ids in np.array_split(np.random.shuffle(self.substation_ids), 3)])
+
+    def test_rules_areas(self):
+        params = Parameters()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            for rules in [self.rules_1area, self.rules_2areas, self.rules_3areas]:
+                env_ref = make(
+                        "l2rpn_case14_sandbox",
+                        test=True,
+                        param=params,
+                        gamerules_class = rules
+                    )
+                lines_by_area = env_ref._game_rules.legal_action.lines_id_by_area
+                line_select = [[int(k) for k in np.random.choice(list_ids, size=3, replace=False)] for list_ids in lines_by_area]
+                #two lines one sub by area with 1 action in one area per item
+                try:
+                    self.env._parameters.MAX_SUB_CHANGED = 1
+                    self.env._parameters.MAX_LINE_STATUS_CHANGED = 1
+                    for line_select_byarea in line_select:
+                        act = {
+                            "set_line_status": [(LINE_ID, -1) for LINE_ID in line_select_byarea[:2]],
+                            "change_bus" : {"lines_or_id":[LINE_ID for LINE_ID in line_select_byarea[0][-1]]}
+                        }
+                        _ = self.helper_action(
+                            act,
+                            env=self.env,
+                            check_legal=True,
+                        )
+                    raise RuntimeError("This should have thrown an IllegalException")
+                except IllegalAction:
+                    pass
+
+                #one line two sub by area with 1 action in one area per item
+                try:
+                    self.env._parameters.MAX_SUB_CHANGED = 1
+                    self.env._parameters.MAX_LINE_STATUS_CHANGED = 1
+                    for line_select_byarea in line_select:
+                        act = {
+                            "set_line_status": [(LINE_ID, -1) for LINE_ID in line_select_byarea[0]],
+                            "change_bus" : {"lines_or_id":[LINE_ID for LINE_ID in line_select_byarea[0][-2:]]}
+                        }
+                        _ = self.helper_action(
+                            act,
+                            env=self.env,
+                            check_legal=True,
+                        )
+                    raise RuntimeError("This should have thrown an IllegalException")
+                except IllegalAction:
+                    pass
+
+                #one line one sub with one action per area per item per area
+                self.env._parameters.MAX_SUB_CHANGED = 1
+                self.env._parameters.MAX_LINE_STATUS_CHANGED = 1
+                act = {
+                        "set_line_status": [(LINE_ID, -1) for LINE_ID in list(chain(*[list_ids[0] for list_ids in line_select]))],
+                        "change_bus" : {"lines_or_id":[LINE_ID for LINE_ID in list(chain(*[list_ids[1] for list_ids in line_select]))]}
+                }
+                _ = self.helper_action(
+                        act,
+                        env=self.env,
+                        check_legal=True,
+                )
+
+                #two lines one sub with two actions per line one per sub per area
+                self.env._parameters.MAX_SUB_CHANGED = 1
+                self.env._parameters.MAX_LINE_STATUS_CHANGED = 2
+                act = {
+                        "set_line_status": [(LINE_ID, -1) for LINE_ID in list(chain(*[list_ids[:2] for list_ids in line_select]))],
+                        "change_bus" : {"lines_or_id":[LINE_ID for LINE_ID in list(chain(*[list_ids[-1] for list_ids in line_select]))]}
+                }
+                _ = self.helper_action(
+                        act,
+                        env=self.env,
+                        check_legal=True,
+                )
+
+                #one line two sub with one action per line two per sub per area
+                self.env._parameters.MAX_SUB_CHANGED = 2
+                self.env._parameters.MAX_LINE_STATUS_CHANGED = 1
+                act = {
+                        "set_line_status": [(LINE_ID, -1) for LINE_ID in list(chain(*[list_ids[0] for list_ids in line_select]))],
+                        "change_bus" : {"lines_or_id":[LINE_ID for LINE_ID in list(chain(*[list_ids[-2:] for list_ids in line_select]))]}
+                }
+                _ = self.helper_action(
+                        act,
+                        env=self.env,
+                        check_legal=True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add DefaultRules to be set for a list of list of substations ids. 
gamerules_class RulesByArea: when called, roll down a list of default rules. Use a custom LookParam function to check number of lines and substations allowed to have their status changed.
Basically look for MAX_LINE_STATUS_CHANGED and MAX_SUB_CHANGED and allow these numbers by each defined area.
No changes for PreventDiscoStorageModif and PreventReconnection as whose behaviours are not affected by zonal rules.