### PR TITLE
fix issue 446: problem with BoxGymObsSpace when normalizing

### DIFF
--- a/grid2op/gym_compat/box_gym_obsspace.py
+++ b/grid2op/gym_compat/box_gym_obsspace.py
@@ -618,10 +618,10 @@ class __AuxBoxGymObsSpace:
 
         if subtract is None:
             subtract = {}
-        self._subtract = subtract
+        self._subtract = subtract.copy()
         if divide is None:
             divide = {}
-        self._divide = divide
+        self._divide = divide.copy()
 
         # handle the "functional" part
         self._template_obs = ob_sp._template_obj.copy()

--- a/grid2op/tests/test_issue_446.py
+++ b/grid2op/tests/test_issue_446.py
@@ -19,21 +19,26 @@ class Issue446Tester(unittest.TestCase):
         env = grid2op.make("l2rpn_case14_sandbox", test=True)
 
         divide = {"hour_of_day": np.ones(1)}
+        subtract = {"hour_of_day": np.zeros(1)}
 
         gym_observation_space_1 =  BoxGymObsSpace(env.observation_space,
                                                 attr_to_keep=["curtailment_mw", "hour_of_day"],
-                                                divide = divide
+                                                divide = divide,
+                                                subtract = subtract
                                                 )
 
         gym_observation_space_2 =  BoxGymObsSpace(env.observation_space.copy(),
                                                 attr_to_keep=["curtailment_mw", "hour_of_day"],
-                                                divide = divide
+                                                divide = divide,
+                                                subtract = subtract
                                                 )
         
         gym_observation_space_1.normalize_attr("curtailment_mw")
             
         assert "curtailment_mw" in gym_observation_space_1._divide
         assert "curtailment_mw" not in gym_observation_space_2._divide
+        assert "curtailment_mw" in gym_observation_space_1._subtract
+        assert "curtailment_mw" not in gym_observation_space_2._subtract
         
         
 if __name__ == "__main__":

--- a/grid2op/tests/test_issue_446.py
+++ b/grid2op/tests/test_issue_446.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+
+import grid2op
+from grid2op.gym_compat import BoxGymActSpace, BoxGymObsSpace
+import numpy as np
+import unittest
+
+
+class Issue446Tester(unittest.TestCase):
+    def test_box_action_space(self):
+        # We considers only redispatching actions
+        env = grid2op.make("l2rpn_case14_sandbox", test=True)
+
+        divide = {"hour_of_day": np.ones(1)}
+
+        gym_observation_space_1 =  BoxGymObsSpace(env.observation_space,
+                                                attr_to_keep=["curtailment_mw", "hour_of_day"],
+                                                divide = divide
+                                                )
+
+        gym_observation_space_2 =  BoxGymObsSpace(env.observation_space.copy(),
+                                                attr_to_keep=["curtailment_mw", "hour_of_day"],
+                                                divide = divide
+                                                )
+        
+        gym_observation_space_1.normalize_attr("curtailment_mw")
+            
+        assert "curtailment_mw" in gym_observation_space_1._divide
+        assert "curtailment_mw" not in gym_observation_space_2._divide
+        
+        
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The following bug is fixed:
Two identical BoxGymObsSpace objects are created and called gym_observation_space_1 and gym_observation_space_2.
Using the normalize_attr method on gym_observation_space_1 also impacted gym_observation_space_2, which was undesirable.