### PR TITLE
Dev 1.9.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,27 +3,27 @@ version: 2.1
 executors:
     grid2op-executor:
         docker:
-            - image: python:3.10-buster
+            - image: python:3.10
         working_directory: /Grid2Op
 
     python37:
         docker:
-            - image: python:3.7-buster
+            - image: python:3.7
     python38:
         docker:
-            - image: python:3.8-buster
+            - image: python:3.8
     python39:
         docker:
-            - image: python:3.9-buster
+            - image: python:3.9
     python310:
         docker:
-            - image: python:3.10-buster
+            - image: python:3.10
     python311:
         docker:
-            - image: python:3.11-buster
+            - image: python:3.11
     python312:
         docker:
-            - image: cimg/python:3.12.0
+            - image: cimg/python:3.12
 
 jobs:
     test:
@@ -140,27 +140,27 @@ jobs:
                    python -m pip install -U .[test]
                    export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.21,<1.22"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.22,<1.23"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.23,<1.24"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.21,<1.22"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.22,<1.23"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.23,<1.24"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
@@ -187,53 +187,53 @@ jobs:
                    python -m pip install -U pip setuptools wheel
                    python -m pip install chronix2grid>="1.1.0.post1"
                    python -m pip uninstall -y grid2op
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U numba
-                   python -m pip install -U .[test]
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.20,<1.21"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.21,<1.22"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.22,<1.23"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.23,<1.24"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.24,<1.25"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.25,<1.26"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U numba
+            #        python -m pip install -U .[test]
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.20,<1.21"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.21,<1.22"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.22,<1.23"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.23,<1.24"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.24,<1.25"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.25,<1.26"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
@@ -265,34 +265,34 @@ jobs:
                    python -m pip install -U .[test]
                    export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.22,<1.23"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.23,<1.24"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.24,<1.25"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.25,<1.26"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.22,<1.23"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.23,<1.24"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.24,<1.25"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.25,<1.26"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
@@ -324,20 +324,20 @@ jobs:
                    python -m pip install -U .[test]
                    export _GRID2OP_FORCE_TEST=1
                    grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.24,<1.25"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
-            - run:
-               command: |
-                   source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.25,<1.26"
-                   python -m pip install -U .[test]
-                   export _GRID2OP_FORCE_TEST=1
-                   grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.24,<1.25"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
+            # - run:
+            #    command: |
+            #        source venv_test/bin/activate
+            #        python -m pip install -U "numpy>=1.25,<1.26"
+            #        python -m pip install -U .[test]
+            #        export _GRID2OP_FORCE_TEST=1
+            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
@@ -380,4 +380,4 @@ workflows:
           - install39
           - install310
           - install311
-        #   - install312  # failing because of dependencies of numba, torch etc. Tired of it so ignoring it !
+          - install312  # failing because of dependencies of numba, torch etc. Tired of it so ignoring it !

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,17 @@ jobs:
                   export _GRID2OP_FORCE_TEST=1
                   cd grid2op/tests/
                   python3 helper_list_test.py | circleci tests split > /tmp/tests_run
+            - run:
+                command: |
+                  source venv_test/bin/activate
+                  pip freeze
             - run: cat /tmp/tests_run
             - run:
                 command: |
                   source venv_test/bin/activate
                   cd grid2op/tests/
                   export _GRID2OP_FORCE_TEST=1
-                  python3 -m unittest $(cat /tmp/tests_run)
+                  python3 -m unittest -v $(cat /tmp/tests_run)
                   
     install36:
         executor: python36
@@ -136,37 +140,28 @@ jobs:
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.20,<1.21"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.20,<1.21" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.21,<1.22"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.22,<1.23"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.23,<1.24"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.24,<1.25"
+                   python -m pip install -U "numpy>=1.24,<1.25" "pandas<2.2" "scipy<1.12" numba
                    python -m pip install -U .[test]
+            - run:
+                command: |
+                   source venv_test/bin/activate
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
 
     install39:
@@ -187,59 +182,27 @@ jobs:
                    python -m pip install -U pip setuptools wheel
                    python -m pip install chronix2grid>="1.1.0.post1"
                    python -m pip uninstall -y grid2op
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U numba
-            #        python -m pip install -U .[test]
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.20,<1.21"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.21,<1.22"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.22,<1.23"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.23,<1.24"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.24,<1.25"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.25,<1.26"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.26,<1.27"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.20,<1.21" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
+                   grid2op.testinstall
+            - run:
+               command: |
+                   source venv_test/bin/activate
+                   python -m pip install -U "numpy>=1.26,<1.27" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
+                   export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
 
     install310:
@@ -261,44 +224,24 @@ jobs:
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.21,<1.22"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.21,<1.22" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.22,<1.23"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.23,<1.24"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.24,<1.25"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.25,<1.26"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.26,<1.27"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.26,<1.27" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
 
     install311:
@@ -316,34 +259,27 @@ jobs:
                command: |
                    source venv_test/bin/activate
                    python -m pip install -U pip setuptools wheel
-                   python -m pip install -U numba
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.23,<1.24"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.23,<1.24" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.24,<1.25"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
-            # - run:
-            #    command: |
-            #        source venv_test/bin/activate
-            #        python -m pip install -U "numpy>=1.25,<1.26"
-            #        python -m pip install -U .[test]
-            #        export _GRID2OP_FORCE_TEST=1
-            #        grid2op.testinstall
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.26,<1.27"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.26,<1.27" "pandas<2.2" "scipy<1.12" numba .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
     install312:
         executor: python312
@@ -364,9 +300,13 @@ jobs:
             - run:
                command: |
                    source venv_test/bin/activate
-                   python -m pip install -U "numpy>=1.26,<1.27"
-                   python -m pip install -U .[test]
+                   python -m pip install -U "numpy>=1.26,<1.27" "pandas<2.2" "scipy<1.12" .[test]
+                   pip freeze
+            - run:
+                command: |
+                   source venv_test/bin/activate
                    export _GRID2OP_FORCE_TEST=1
+                   cd /tmp
                    grid2op.testinstall
 
 workflows:
@@ -380,4 +320,4 @@ workflows:
           - install39
           - install310
           - install311
-          - install312  # failing because of dependencies of numba, torch etc. Tired of it so ignoring it !
+          - install312

--- a/.gitignore
+++ b/.gitignore
@@ -397,6 +397,8 @@ grid2op/tests/test_failing_simulator.txt
 old_pyproject.toml
 pp_bug_gen_alone.py
 test_dunder.py
+grid2op/tests/test_fail_ci.txt
+saved_multiepisode_agent_36bus_DN_4/
 
 # profiling files
 **.prof

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,14 @@
-version: 2
+version: "2"
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
 
 python:
-    version: 3.8
     install:
        - method: pip
          path: .

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,14 @@ Change Log
 - [???] properly model interconnecting powerlines
 
 
+[1.9.8] - 20xx-yy-zz
+----------------------
+- [IMPROVED] the CI speed: by not testing every possible numpy version but only most ancient and most recent
+- [IMPROVED] Runner now test grid2op version 1.9.6 and 1.9.7
+- [IMPROVED] refacto `gridobj_cls._clear_class_attribute` and `gridobj_cls._clear_grid_dependant_class_attributes`
+- [IMPROVED] the bahviour of the generic class `MakeBackend` used for the test suite.
+- [IMPROVED] re introducing python 12 testing
+
 [1.9.7] - 2023-12-01
 ----------------------
 - [BREAKING] removal of the `grid2op/Exceptions/PowerflowExceptions.py` file and move the

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,11 +34,19 @@ Change Log
 
 [1.9.8] - 20xx-yy-zz
 ----------------------
+- [FIXED] the `backend.check_kirchoff` function was not correct when some elements were disconnected 
+  (the wrong columns of the p_bus and q_bus was set in case of disconnected elements)
+- [FIXED] `PandapowerBackend`, when no slack was present
+- [FIXED] the "BaseBackendTest" class did not correctly detect divergence in most cases (which lead 
+  to weird bugs in failing tests)
+- [ADDED] A type of environment that does not perform the "emulation of the protections"
+  for some part of the grid (`MaskedEnvironment`) see https://github.com/rte-france/Grid2Op/issues/571
 - [IMPROVED] the CI speed: by not testing every possible numpy version but only most ancient and most recent
 - [IMPROVED] Runner now test grid2op version 1.9.6 and 1.9.7
 - [IMPROVED] refacto `gridobj_cls._clear_class_attribute` and `gridobj_cls._clear_grid_dependant_class_attributes`
 - [IMPROVED] the bahviour of the generic class `MakeBackend` used for the test suite.
 - [IMPROVED] re introducing python 12 testing
+- [IMPROVED] error messages in the automatic test suite (`AAATestBackendAPI`)
 
 [1.9.7] - 2023-12-01
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,8 +40,14 @@ Change Log
 - [FIXED] the "BaseBackendTest" class did not correctly detect divergence in most cases (which lead 
   to weird bugs in failing tests)
 - [FIXED] an issue with imageio having deprecated the `fps` kwargs (see https://github.com/rte-france/Grid2Op/issues/569)
+- [FIXED] adding the "`loads_charac.csv`" in the package data
+- [FIXED] a bug when using grid2op, not "utils.py" script could be used (see 
+  https://github.com/rte-france/Grid2Op/issues/577). This was caused by the modification of
+  `sys.path` when importing the grid2op test suite.
 - [ADDED] A type of environment that does not perform the "emulation of the protections"
   for some part of the grid (`MaskedEnvironment`) see https://github.com/rte-france/Grid2Op/issues/571
+- [ADDED] a "gym like" API for reset allowing to set the seed and the time serie id directly when calling
+  `env.reset(seed=.., options={"time serie id": ...})`
 - [IMPROVED] the CI speed: by not testing every possible numpy version but only most ancient and most recent
 - [IMPROVED] Runner now test grid2op version 1.9.6 and 1.9.7
 - [IMPROVED] refacto `gridobj_cls._clear_class_attribute` and `gridobj_cls._clear_grid_dependant_class_attributes`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Change Log
 - [FIXED] `PandapowerBackend`, when no slack was present
 - [FIXED] the "BaseBackendTest" class did not correctly detect divergence in most cases (which lead 
   to weird bugs in failing tests)
+- [FIXED] an issue with imageio having deprecated the `fps` kwargs (see https://github.com/rte-france/Grid2Op/issues/569)
 - [ADDED] A type of environment that does not perform the "emulation of the protections"
   for some part of the grid (`MaskedEnvironment`) see https://github.com/rte-france/Grid2Op/issues/571
 - [IMPROVED] the CI speed: by not testing every possible numpy version but only most ancient and most recent

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Change Log
 - [???] properly model interconnecting powerlines
 
 
-[1.9.8] - 20xx-yy-zz
+[1.9.8] - 2024-01-26
 ----------------------
 - [FIXED] the `backend.check_kirchoff` function was not correct when some elements were disconnected 
   (the wrong columns of the p_bus and q_bus was set in case of disconnected elements)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include grid2op/data *.bz2 *.json *.zip prods_charac.csv *.py .multimix storage_units_charac.csv start_datetime.info time_interval.info
+recursive-include grid2op/data *.bz2 *.json *.zip loads_charac.csv prods_charac.csv *.py .multimix storage_units_charac.csv start_datetime.info time_interval.info
 global-exclude */__pycache__/*
 global-exclude *.pyc
 global-exclude  grid2op/data_test/*

--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ but it is currently not on our priorities.
 A quick fix that is known to work include to set the `experimental_read_from_local_dir` when creating the
 environment with `grid2op.make(..., experimental_read_from_local_dir=True)` (see doc for more information)
 
+Sometimes, on some configuration (python version) we do not recommend to use grid2op with pandas>=2.2
+If you encounter any trouble, please downgrade to pandas<2.2. This behaviour occured in our continuous 
+integration environment for python >=3.9 but could not be reproduced locally.
+
 ### Perform tests locally
 
 Provided that Grid2Op is installed *from source*:

--- a/docs/action.rst
+++ b/docs/action.rst
@@ -85,7 +85,7 @@ you want to perform on the grid. For more information you can consult the help o
 
 To avoid extremely verbose things, as of grid2op 1.5.0, we introduced some convenience functions to allow
 easier action construction. You can now do `act.load_set_bus = ...` instead of the previously way
-more verbose `act.update({"set_bus": {"loads_id": ...}}`
+more verbose `act.update({"set_bus": {"loads_id": ...}})`
 
 .. _action-module-examples:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, RTE France'
 author = 'Benjamin Donnot'
 
 # The full version, including alpha/beta/rc tags
-release = '1.9.8.dev0'
+release = '1.9.8.dev1'
 version = '1.9'
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, RTE France'
 author = 'Benjamin Donnot'
 
 # The full version, including alpha/beta/rc tags
-release = '1.9.7'
+release = '1.9.8.dev0'
 version = '1.9'
 
 

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -101,7 +101,7 @@ be equivalent to starting into the "middle" of a video game. If that is the case
 Finally, you might have noticed that each call to "env.reset" might take a while. This can dramatically
 increase the training time, especially at the beginning. This is due to the fact that each time
 `env.reset` is called, the whole chronics is read from the hard drive. If you want to lower this
-impact then you might consult the `Optimize the data pipeline`_ section.
+impact then you might consult the :ref:`environment-module-data-pipeline` page of the doc.
 
 .. _environment-module-chronics-info:
 

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -1023,10 +1023,12 @@ class Backend(GridObjects, ABC):
             ] = True
 
             # disconnect the current power lines
-            if to_disc[lines_status].sum() == 0:
-                # no powerlines have been disconnected at this time step, i stop the computation there
+            if to_disc[lines_status].any() == 0:
+                # no powerlines have been disconnected at this time step, 
+                # i stop the computation there
                 break
             disconnected_during_cf[to_disc] = ts
+            
             # perform the disconnection action
             for i, el in enumerate(to_disc):
                 if el:
@@ -1124,18 +1126,19 @@ class Backend(GridObjects, ABC):
         p_ex, q_ex, v_ex, *_ = self.lines_ex_info()
         p_gen, q_gen, v_gen = self.generators_info()
         p_load, q_load, v_load = self.loads_info()
-        if self.n_storage > 0:
+        cls = type(self)
+        if cls.n_storage > 0:
             p_storage, q_storage, v_storage = self.storages_info()
 
         # fist check the "substation law" : nothing is created at any substation
-        p_subs = np.zeros(self.n_sub, dtype=dt_float)
-        q_subs = np.zeros(self.n_sub, dtype=dt_float)
+        p_subs = np.zeros(cls.n_sub, dtype=dt_float)
+        q_subs = np.zeros(cls.n_sub, dtype=dt_float)
 
         # check for each bus
-        p_bus = np.zeros((self.n_sub, 2), dtype=dt_float)
-        q_bus = np.zeros((self.n_sub, 2), dtype=dt_float)
+        p_bus = np.zeros((cls.n_sub, 2), dtype=dt_float)
+        q_bus = np.zeros((cls.n_sub, 2), dtype=dt_float)
         v_bus = (
-            np.zeros((self.n_sub, 2, 2), dtype=dt_float) - 1.0
+            np.zeros((cls.n_sub, 2, 2), dtype=dt_float) - 1.0
         )  # sub, busbar, [min,max]
         topo_vect = self.get_topo_vect()
 
@@ -1143,11 +1146,15 @@ class Backend(GridObjects, ABC):
         # for example, if two powerlines are such that line_or_to_subid is equal (eg both connected to substation 0)
         # then numpy do not guarantee that `p_subs[self.line_or_to_subid] += p_or` will add the two "corresponding p_or"
         # TODO this can be vectorized with matrix product, see example in obs.flow_bus_matrix (BaseObervation.py)
-        for i in range(self.n_line):
-            sub_or_id = self.line_or_to_subid[i]
-            sub_ex_id = self.line_ex_to_subid[i]
-            loc_bus_or = topo_vect[self.line_or_pos_topo_vect[i]] - 1
-            loc_bus_ex = topo_vect[self.line_ex_pos_topo_vect[i]] - 1
+        for i in range(cls.n_line):
+            sub_or_id = cls.line_or_to_subid[i]
+            sub_ex_id = cls.line_ex_to_subid[i]
+            if (topo_vect[cls.line_or_pos_topo_vect[i]] == -1 or
+                topo_vect[cls.line_ex_pos_topo_vect[i]] == -1):
+                # line is disconnected
+                continue
+            loc_bus_or = topo_vect[cls.line_or_pos_topo_vect[i]] - 1
+            loc_bus_ex = topo_vect[cls.line_ex_pos_topo_vect[i]] - 1
             
             # for substations
             p_subs[sub_or_id] += p_or[i]
@@ -1184,92 +1191,104 @@ class Backend(GridObjects, ABC):
                 v_bus[sub_ex_id,loc_bus_ex,][0] = min(v_bus[sub_ex_id,loc_bus_ex,][0],v_ex[i],)
                 v_bus[sub_ex_id,loc_bus_ex,][1] = max(v_bus[sub_ex_id,loc_bus_ex,][1],v_ex[i],)
         
-        for i in range(self.n_gen):
+        for i in range(cls.n_gen):
+            if topo_vect[cls.gen_pos_topo_vect[i]] == -1:
+                # gen is disconnected
+                continue
+            
             # for substations
-            p_subs[self.gen_to_subid[i]] -= p_gen[i]
-            q_subs[self.gen_to_subid[i]] -= q_gen[i]
+            p_subs[cls.gen_to_subid[i]] -= p_gen[i]
+            q_subs[cls.gen_to_subid[i]] -= q_gen[i]
 
             # for bus
             p_bus[
-                self.gen_to_subid[i], topo_vect[self.gen_pos_topo_vect[i]] - 1
+                cls.gen_to_subid[i], topo_vect[cls.gen_pos_topo_vect[i]] - 1
             ] -= p_gen[i]
             q_bus[
-                self.gen_to_subid[i], topo_vect[self.gen_pos_topo_vect[i]] - 1
+                cls.gen_to_subid[i], topo_vect[cls.gen_pos_topo_vect[i]] - 1
             ] -= q_gen[i]
 
             # compute max and min values
             if v_gen[i]:
                 # but only if gen is connected
-                v_bus[self.gen_to_subid[i], topo_vect[self.gen_pos_topo_vect[i]] - 1][
+                v_bus[cls.gen_to_subid[i], topo_vect[cls.gen_pos_topo_vect[i]] - 1][
                     0
                 ] = min(
                     v_bus[
-                        self.gen_to_subid[i], topo_vect[self.gen_pos_topo_vect[i]] - 1
+                        cls.gen_to_subid[i], topo_vect[cls.gen_pos_topo_vect[i]] - 1
                     ][0],
                     v_gen[i],
                 )
-                v_bus[self.gen_to_subid[i], topo_vect[self.gen_pos_topo_vect[i]] - 1][
+                v_bus[cls.gen_to_subid[i], topo_vect[cls.gen_pos_topo_vect[i]] - 1][
                     1
                 ] = max(
                     v_bus[
-                        self.gen_to_subid[i], topo_vect[self.gen_pos_topo_vect[i]] - 1
+                        cls.gen_to_subid[i], topo_vect[cls.gen_pos_topo_vect[i]] - 1
                     ][1],
                     v_gen[i],
                 )
 
-        for i in range(self.n_load):
+        for i in range(cls.n_load):
+            if topo_vect[cls.load_pos_topo_vect[i]] == -1:
+                # load is disconnected
+                continue
+            
             # for substations
-            p_subs[self.load_to_subid[i]] += p_load[i]
-            q_subs[self.load_to_subid[i]] += q_load[i]
+            p_subs[cls.load_to_subid[i]] += p_load[i]
+            q_subs[cls.load_to_subid[i]] += q_load[i]
 
             # for buses
             p_bus[
-                self.load_to_subid[i], topo_vect[self.load_pos_topo_vect[i]] - 1
+                cls.load_to_subid[i], topo_vect[cls.load_pos_topo_vect[i]] - 1
             ] += p_load[i]
             q_bus[
-                self.load_to_subid[i], topo_vect[self.load_pos_topo_vect[i]] - 1
+                cls.load_to_subid[i], topo_vect[cls.load_pos_topo_vect[i]] - 1
             ] += q_load[i]
 
             # compute max and min values
             if v_load[i]:
                 # but only if load is connected
-                v_bus[self.load_to_subid[i], topo_vect[self.load_pos_topo_vect[i]] - 1][
+                v_bus[cls.load_to_subid[i], topo_vect[cls.load_pos_topo_vect[i]] - 1][
                     0
                 ] = min(
                     v_bus[
-                        self.load_to_subid[i], topo_vect[self.load_pos_topo_vect[i]] - 1
+                        cls.load_to_subid[i], topo_vect[cls.load_pos_topo_vect[i]] - 1
                     ][0],
                     v_load[i],
                 )
-                v_bus[self.load_to_subid[i], topo_vect[self.load_pos_topo_vect[i]] - 1][
+                v_bus[cls.load_to_subid[i], topo_vect[cls.load_pos_topo_vect[i]] - 1][
                     1
                 ] = max(
                     v_bus[
-                        self.load_to_subid[i], topo_vect[self.load_pos_topo_vect[i]] - 1
+                        cls.load_to_subid[i], topo_vect[cls.load_pos_topo_vect[i]] - 1
                     ][1],
                     v_load[i],
                 )
 
-        for i in range(self.n_storage):
-            p_subs[self.storage_to_subid[i]] += p_storage[i]
-            q_subs[self.storage_to_subid[i]] += q_storage[i]
+        for i in range(cls.n_storage):
+            if topo_vect[cls.storage_pos_topo_vect[i]] == -1:
+                # storage is disconnected
+                continue
+            
+            p_subs[cls.storage_to_subid[i]] += p_storage[i]
+            q_subs[cls.storage_to_subid[i]] += q_storage[i]
             p_bus[
-                self.storage_to_subid[i], topo_vect[self.storage_pos_topo_vect[i]] - 1
+                cls.storage_to_subid[i], topo_vect[cls.storage_pos_topo_vect[i]] - 1
             ] += p_storage[i]
             q_bus[
-                self.storage_to_subid[i], topo_vect[self.storage_pos_topo_vect[i]] - 1
+                cls.storage_to_subid[i], topo_vect[cls.storage_pos_topo_vect[i]] - 1
             ] += q_storage[i]
 
             # compute max and min values
             if v_storage[i] > 0:
                 # the storage unit is connected
                 v_bus[
-                    self.storage_to_subid[i],
-                    topo_vect[self.storage_pos_topo_vect[i]] - 1,
+                    cls.storage_to_subid[i],
+                    topo_vect[cls.storage_pos_topo_vect[i]] - 1,
                 ][0] = min(
                     v_bus[
-                        self.storage_to_subid[i],
-                        topo_vect[self.storage_pos_topo_vect[i]] - 1,
+                        cls.storage_to_subid[i],
+                        topo_vect[cls.storage_pos_topo_vect[i]] - 1,
                     ][0],
                     v_storage[i],
                 )
@@ -1278,29 +1297,33 @@ class Backend(GridObjects, ABC):
                     topo_vect[self.storage_pos_topo_vect[i]] - 1,
                 ][1] = max(
                     v_bus[
-                        self.storage_to_subid[i],
-                        topo_vect[self.storage_pos_topo_vect[i]] - 1,
+                        cls.storage_to_subid[i],
+                        topo_vect[cls.storage_pos_topo_vect[i]] - 1,
                     ][1],
                     v_storage[i],
                 )
 
-        if type(self).shunts_data_available:
+        if cls.shunts_data_available:
             p_s, q_s, v_s, bus_s = self.shunt_info()
-            for i in range(self.n_shunt):
+            for i in range(cls.n_shunt):
+                if bus_s[i] == -1:
+                    # shunt is disconnected
+                    continue
+                
                 # for substations
-                p_subs[self.shunt_to_subid[i]] += p_s[i]
-                q_subs[self.shunt_to_subid[i]] += q_s[i]
+                p_subs[cls.shunt_to_subid[i]] += p_s[i]
+                q_subs[cls.shunt_to_subid[i]] += q_s[i]
 
                 # for buses
-                p_bus[self.shunt_to_subid[i], bus_s[i] - 1] += p_s[i]
-                q_bus[self.shunt_to_subid[i], bus_s[i] - 1] += q_s[i]
+                p_bus[cls.shunt_to_subid[i], bus_s[i] - 1] += p_s[i]
+                q_bus[cls.shunt_to_subid[i], bus_s[i] - 1] += q_s[i]
 
                 # compute max and min values
-                v_bus[self.shunt_to_subid[i], bus_s[i] - 1][0] = min(
-                    v_bus[self.shunt_to_subid[i], bus_s[i] - 1][0], v_s[i]
+                v_bus[cls.shunt_to_subid[i], bus_s[i] - 1][0] = min(
+                    v_bus[cls.shunt_to_subid[i], bus_s[i] - 1][0], v_s[i]
                 )
-                v_bus[self.shunt_to_subid[i], bus_s[i] - 1][1] = max(
-                    v_bus[self.shunt_to_subid[i], bus_s[i] - 1][1], v_s[i]
+                v_bus[cls.shunt_to_subid[i], bus_s[i] - 1][1] = max(
+                    v_bus[cls.shunt_to_subid[i], bus_s[i] - 1][1], v_s[i]
                 )
         else:
             warnings.warn(

--- a/grid2op/Environment/__init__.py
+++ b/grid2op/Environment/__init__.py
@@ -5,7 +5,8 @@ __all__ = [
     "SingleEnvMultiProcess",
     "MultiEnvMultiProcess",
     "MultiMixEnvironment",
-    "TimedOutEnvironment"
+    "TimedOutEnvironment",
+    "MaskedEnvironment"
 ]
 
 from grid2op.Environment.baseEnv import BaseEnv
@@ -15,3 +16,4 @@ from grid2op.Environment.singleEnvMultiProcess import SingleEnvMultiProcess
 from grid2op.Environment.multiEnvMultiProcess import MultiEnvMultiProcess
 from grid2op.Environment.multiMixEnv import MultiMixEnvironment
 from grid2op.Environment.timedOutEnv import TimedOutEnvironment
+from grid2op.Environment.maskedEnvironment import MaskedEnvironment

--- a/grid2op/Environment/baseEnv.py
+++ b/grid2op/Environment/baseEnv.py
@@ -342,7 +342,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         )
         self._timestep_overflow: np.ndarray = None
         self._nb_timestep_overflow_allowed: np.ndarray = None
-        self._hard_overflow_threshold: float = self._parameters.HARD_OVERFLOW_THRESHOLD
+        self._hard_overflow_threshold: np.ndarray  = None
 
         # store actions "cooldown"
         self._times_before_line_status_actionable: np.ndarray = None
@@ -626,7 +626,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         new_obj._nb_timestep_overflow_allowed = copy.deepcopy(
             self._nb_timestep_overflow_allowed
         )
-        new_obj._hard_overflow_threshold = self._hard_overflow_threshold
+        new_obj._hard_overflow_threshold = copy.deepcopy(self._hard_overflow_threshold)
 
         # store actions "cooldown"
         new_obj._times_before_line_status_actionable = copy.deepcopy(
@@ -1204,7 +1204,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         self._gen_downtime = np.zeros(self.n_gen, dtype=dt_int)
         self._gen_activeprod_t = np.zeros(self.n_gen, dtype=dt_float)
         self._gen_activeprod_t_redisp = np.zeros(self.n_gen, dtype=dt_float)
-        self._nb_timestep_overflow_allowed = np.ones(shape=self.n_line, dtype=dt_int)
         self._max_timestep_line_status_deactivated = (
             self._parameters.NB_TIMESTEP_COOLDOWN_LINE
         )
@@ -1219,6 +1218,11 @@ class BaseEnv(GridObjects, RandomObject, ABC):
             shape=(self.n_line,),
             fill_value=self._parameters.NB_TIMESTEP_OVERFLOW_ALLOWED,
             dtype=dt_int,
+        )
+        self._hard_overflow_threshold = np.full(
+            shape=(self.n_line,),
+            fill_value=self._parameters.HARD_OVERFLOW_THRESHOLD,
+            dtype=dt_float,
         )
         self._timestep_overflow = np.zeros(shape=(self.n_line,), dtype=dt_int)
 
@@ -1261,7 +1265,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         # type of power flow to play
         # if True, then it will not disconnect lines above their thermal limits
         self._no_overflow_disconnection = self._parameters.NO_OVERFLOW_DISCONNECTION
-        self._hard_overflow_threshold = self._parameters.HARD_OVERFLOW_THRESHOLD
 
         # store actions "cooldown"
         self._max_timestep_line_status_deactivated = (
@@ -1275,7 +1278,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         self._nb_timestep_overflow_allowed[
             :
         ] = self._parameters.NB_TIMESTEP_OVERFLOW_ALLOWED
-
+        self._hard_overflow_threshold[:] = self._parameters.HARD_OVERFLOW_THRESHOLD
         # hard overflow part
         self._env_dc = self._parameters.ENV_DC
 
@@ -2957,16 +2960,19 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         # TODO is non zero and disconnected, this should be ok.
         self._time_extract_obs += time.perf_counter() - beg_res
 
+    def _backend_next_grid_state(self):
+        """overlaoded in MaskedEnv"""
+        return self.backend.next_grid_state(env=self, is_dc=self._env_dc)
+    
     def _aux_run_pf_after_state_properly_set(
         self, action, init_line_status, new_p, except_
     ):
         has_error = True
+        detailed_info = None
         try:
             # compute the next _grid state
             beg_pf = time.perf_counter()
-            disc_lines, detailed_info, conv_ = self.backend.next_grid_state(
-                env=self, is_dc=self._env_dc
-            )
+            disc_lines, detailed_info, conv_ = self._backend_next_grid_state()
             self._disc_lines[:] = disc_lines
             self._time_powerflow += time.perf_counter() - beg_pf
             if conv_ is None:
@@ -3327,7 +3333,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         ] = self._parameters.NB_TIMESTEP_OVERFLOW_ALLOWED
 
         self.nb_time_step = 0  # to have the first step at 0
-        self._hard_overflow_threshold = self._parameters.HARD_OVERFLOW_THRESHOLD
+        self._hard_overflow_threshold[:] = self._parameters.HARD_OVERFLOW_THRESHOLD
         self._env_dc = self._parameters.ENV_DC
 
         self._times_before_line_status_actionable[:] = 0

--- a/grid2op/Environment/environment.py
+++ b/grid2op/Environment/environment.py
@@ -37,6 +37,14 @@ class Environment(BaseEnv):
     """
     This class is the grid2op implementation of the "Environment" entity in the RL framework.
 
+    .. danger::
+    
+        Long story short, once a environment is deleted, you cannot use anything it "holds" including,
+        but not limited to the capacity to perform `obs.simulate(...)` even if the `obs` is still
+        referenced.
+        
+        See :ref:`danger-env-ownership` (first danger block). 
+        
     Attributes
     ----------
 

--- a/grid2op/Environment/environment.py
+++ b/grid2op/Environment/environment.py
@@ -418,7 +418,7 @@ class Environment(BaseEnv):
             raise Grid2OpException(
                 "Impossible to initialize the powergrid, the powerflow diverge at iteration 0. "
                 "Available information are: {}".format(info)
-            )
+            ) from info["exception"][0]
 
         # test the backend returns object of the proper size
         if need_process_backend:

--- a/grid2op/Environment/maskedEnvironment.py
+++ b/grid2op/Environment/maskedEnvironment.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import copy
+import numpy as np
+from typing import Tuple, Union, List
+from grid2op.Environment.environment import Environment
+from grid2op.Action import BaseAction
+from grid2op.Observation import BaseObservation
+from grid2op.Exceptions import EnvError
+from grid2op.dtypes import dt_bool, dt_float, dt_int
+
+
+class MaskedEnvironment(Environment):  # TODO heritage ou alors on met un truc de base
+    """This class is the grid2op implementation of a "maked" environment: lines not in the 
+    `lines_of_interest` mask will NOT be deactivated by the environment is the flow is too high
+    (or moderately high for too long.)
+    
+    .. warning::
+        This class might not behave normally if used with TimeOutEnvironment, MultiEnv, MultiMixEnv etc.
+    
+    .. warning::
+        At time of writing, the behaviour of "obs.simulate" is not modified
+    """  
+    CAN_SKIP_TS = False  # some steps can be more than one time steps
+    def __init__(self,
+                 grid2op_env: Union[Environment, dict],
+                 lines_of_interest):
+        
+        self._lines_of_interest = self._make_lines_of_interest(lines_of_interest)
+        if isinstance(grid2op_env, Environment):
+            super().__init__(**grid2op_env.get_kwargs())
+        elif isinstance(grid2op_env, dict):
+            super().__init__(**grid2op_env)
+        else:
+            raise EnvError(f"For TimedOutEnvironment you need to provide "
+                           f"either an Environment or a dict "
+                           f"for grid2op_env. You provided: {type(grid2op_env)}")
+        
+    def _make_lines_of_interest(self, lines_of_interest):
+        # NB is called BEFORE the env has been created...
+        if isinstance(lines_of_interest, np.ndarray):
+            # if lines_of_interest.size() != type(self).n_line:
+                # raise EnvError("Impossible to init A masked environment when the number of lines "
+                            #    "of the mask do not match the number of lines on the grid.")
+            res = lines_of_interest.astype(dt_bool)
+            if res.sum() == 0:
+                raise EnvError("You cannot use MaskedEnvironment and masking all "
+                               "the grid. If you don't want to simulate powerline "
+                               "disconnection when they are game over, please "
+                               "set params.NO_OVERFLOW_DISCONNECT=True (see doc)")
+        else:
+            raise EnvError("Format of lines_of_interest is not understood. "
+                           "Please provide a vector of the size of the "
+                           "number of lines on the grid.")
+        return res
+    
+    def _reset_vectors_and_timings(self):
+        super()._reset_vectors_and_timings()
+        self._hard_overflow_threshold[~self._lines_of_interest] = 1e-7 * np.finfo(dt_float).max   # some kind of infinity value
+        # NB we multiply np.finfo(dt_float).max by a small number to avoid overflow
+        # indeed, _hard_overflow_threshold is multiply by the flow on the lines
+        self._nb_timestep_overflow_allowed[~self._lines_of_interest] = np.iinfo(dt_int).max - 1  # some kind of infinity value
+
+    def get_kwargs(self, with_backend=True, with_chronics_handler=True):
+        res = {}
+        res["lines_of_interest"] = copy.deepcopy(self._lines_of_interest)
+        res["grid2op_env"] = super().get_kwargs(with_backend, with_chronics_handler)
+        return res
+
+    def get_params_for_runner(self):
+        res = super().get_params_for_runner()
+        res["envClass"] = MaskedEnvironment
+        res["other_env_kwargs"] = {"lines_of_interest": copy.deepcopy(self._lines_of_interest)}
+        return res
+
+    @classmethod
+    def init_obj_from_kwargs(cls,
+                             other_env_kwargs,
+                             init_env_path,
+                             init_grid_path,
+                             chronics_handler,
+                             backend,
+                             parameters,
+                             name,
+                             names_chronics_to_backend,
+                             actionClass,
+                             observationClass,
+                             rewardClass,
+                             legalActClass,
+                             voltagecontrolerClass,
+                             other_rewards,
+                             opponent_space_type,
+                             opponent_action_class,
+                             opponent_class,
+                             opponent_init_budget,
+                             opponent_budget_per_ts,
+                             opponent_budget_class,
+                             opponent_attack_duration,
+                             opponent_attack_cooldown,
+                             kwargs_opponent,
+                             with_forecast,
+                             attention_budget_cls,
+                             kwargs_attention_budget,
+                             has_attention_budget,
+                             logger,
+                             kwargs_observation,
+                             observation_bk_class,
+                             observation_bk_kwargs,
+                             _raw_backend_class,
+                             _read_from_local_dir):
+        res = MaskedEnvironment(grid2op_env={"init_env_path": init_env_path,
+                                             "init_grid_path": init_grid_path,
+                                             "chronics_handler": chronics_handler,
+                                             "backend": backend,
+                                             "parameters": parameters,
+                                             "name": name,
+                                             "names_chronics_to_backend": names_chronics_to_backend,
+                                             "actionClass": actionClass,
+                                             "observationClass": observationClass,
+                                             "rewardClass": rewardClass,
+                                             "legalActClass": legalActClass,
+                                             "voltagecontrolerClass": voltagecontrolerClass,
+                                             "other_rewards": other_rewards,
+                                             "opponent_space_type": opponent_space_type,
+                                             "opponent_action_class": opponent_action_class,
+                                             "opponent_class": opponent_class,
+                                             "opponent_init_budget": opponent_init_budget,
+                                             "opponent_budget_per_ts": opponent_budget_per_ts,
+                                             "opponent_budget_class": opponent_budget_class,
+                                             "opponent_attack_duration": opponent_attack_duration,
+                                             "opponent_attack_cooldown": opponent_attack_cooldown,
+                                             "kwargs_opponent": kwargs_opponent,
+                                             "with_forecast": with_forecast,
+                                             "attention_budget_cls": attention_budget_cls,
+                                             "kwargs_attention_budget": kwargs_attention_budget,
+                                             "has_attention_budget": has_attention_budget,
+                                             "logger": logger,
+                                             "kwargs_observation": kwargs_observation,
+                                             "observation_bk_class": observation_bk_class,
+                                             "observation_bk_kwargs": observation_bk_kwargs,
+                                             "_raw_backend_class": _raw_backend_class,
+                                             "_read_from_local_dir": _read_from_local_dir},
+                                  **other_env_kwargs)
+        return res

--- a/grid2op/Environment/multiEnvMultiProcess.py
+++ b/grid2op/Environment/multiEnvMultiProcess.py
@@ -5,14 +5,12 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
-from multiprocessing import Process, Pipe
+
 import numpy as np
 
 from grid2op.dtypes import dt_int
-from grid2op.Exceptions import Grid2OpException, MultiEnvException
-from grid2op.Space import GridObjects
+from grid2op.Exceptions import MultiEnvException
 from grid2op.Environment.baseMultiProcessEnv import BaseMultiProcessEnvironment
-from grid2op.Action import BaseAction
 
 
 class MultiEnvMultiProcess(BaseMultiProcessEnvironment):

--- a/grid2op/Environment/timedOutEnv.py
+++ b/grid2op/Environment/timedOutEnv.py
@@ -8,7 +8,7 @@
 
 import time
 from math import floor
-from typing import Tuple, Union, List
+from typing import Any, Dict, Tuple, Union, List
 from grid2op.Environment.environment import Environment
 from grid2op.Action import BaseAction
 from grid2op.Observation import BaseObservation
@@ -247,10 +247,17 @@ class TimedOutEnvironment(Environment):  # TODO heritage ou alors on met un truc
                                                "_read_from_local_dir": _read_from_local_dir},
                                   **other_env_kwargs)
         return res
-            
-    def reset(self) -> BaseObservation:
+    
+
+    def reset(self, 
+              *,
+              seed: Union[int, None] = None,
+              options: Union[Dict[str, Any], None] = None) -> BaseObservation:
         """Reset the environment.
 
+        .. seealso::
+            The doc of :func:`Environment.reset` for more information
+            
         Returns
         -------
         BaseObservation
@@ -260,7 +267,7 @@ class TimedOutEnvironment(Environment):  # TODO heritage ou alors on met un truc
         self.__last_act_send = time.perf_counter()
         self.__last_act_received = self.__last_act_send
         self._is_init_dn = False
-        res = super().reset()
+        res = super().reset(seed=seed, options=options)
         self.__last_act_send = time.perf_counter()
         self._is_init_dn = True
         return res

--- a/grid2op/Environment/timedOutEnv.py
+++ b/grid2op/Environment/timedOutEnv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, RTE (https://www.rte-france.com)
+# Copyright (c) 2023, RTE (https://www.rte-france.com)
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
 # If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
@@ -23,7 +23,10 @@ class TimedOutEnvironment(Environment):  # TODO heritage ou alors on met un truc
     of the `step` function. 
     
     For more information, see the documentation of 
-    :func:`TimedOutEnvironment.step` for 
+    :func:`TimedOutEnvironment.step` 
+    
+    .. warning::
+        This class might not behave normally if used with MaskedEnvironment, MultiEnv, MultiMixEnv etc.
     
     Attributes
     ----------

--- a/grid2op/Episode/EpisodeReplay.py
+++ b/grid2op/Episode/EpisodeReplay.py
@@ -102,15 +102,15 @@ class EpisodeReplay(object):
 
         load_info: ``str``
             Defaults to "p". What kind of values to show on loads.
-            Can be oneof `["p", "v", None]`
+            Can be one of `["p", "v", None]`
 
         gen_info: ``str``
             Defaults to "p". What kind of values to show on generators.
-            Can be oneof `["p", "v", None]`
+            Can be one of `["p", "v", None]`
 
         line_info: ``str``
             Defaults to "rho". What kind of values to show on lines.
-            Can be oneof `["rho", "a", "p", "v", None]`
+            Can be one of `["rho", "a", "p", "v", None]`
 
         resolution: ``tuple``
             Defaults to (1280, 720). The resolution to use for the gif.
@@ -187,7 +187,12 @@ class EpisodeReplay(object):
         # Export all frames as gif if enabled
         if gif_name is not None and len(frames) > 0:
             try:
-                imageio.mimwrite(gif_path, frames, fps=fps)
+                try:
+                    # with imageio > 2.5 you need to compute the duration
+                    imageio.mimwrite(gif_path, frames, duration=1000./fps)
+                except TypeError:
+                    # imageio <= 2.5 can be given fps directly
+                    imageio.mimwrite(gif_path, frames, fps=fps)
                 # Try to compress
                 try:
                     from pygifsicle import optimize

--- a/grid2op/Observation/baseObservation.py
+++ b/grid2op/Observation/baseObservation.py
@@ -4207,7 +4207,18 @@ class BaseObservation(GridObjects):
                 f_obs_3, *_ = forecast_env.step(act_3)
                 sim_obs_3, *_ = sim_obs_2.simulate(act_3)
                 # f_obs_3 should be sim_obs_3
-                
+        
+        .. danger::
+    
+            Long story short, once a environment (and a forecast_env is one) 
+            is deleted, you cannot use anything it "holds" including,
+            but not limited to the capacity to perform `obs.simulate(...)` even if the `obs` is still
+            referenced.
+
+            See :ref:`danger-env-ownership` (first danger block). 
+            
+            This caused issue https://github.com/rte-france/Grid2Op/issues/568 for example.
+            
         Returns
         -------
         grid2op.Environment.Environment
@@ -4339,8 +4350,26 @@ class BaseObservation(GridObjects):
             you have 100 rows then you have 100 steps. 
         
         .. warning::
-            We remind that, if you provide some forecasts, it is expected that 
+            We remind that, if you provide some forecasts, it is expected that they allow some powerflow to converge.
+            The balance between total generation on one side and total demand and losses on the other should also
+            make "as close as possible" to reduce some modeling artifact (by the backend, grid2op does not check
+            anything here).
             
+            Finally, make sure that your input data meet the constraints on the generators (pmin, pmax and ramps)
+            otherwise you might end up with incorrect behaviour. Grid2op supposes that data fed to it
+            is consistent with its model. If not it's "undefined behaviour".
+        
+        .. danger::
+    
+            Long story short, once a environment (and a forecast_env is one) 
+            is deleted, you cannot use anything it "holds" including,
+            but not limited to the capacity to perform `obs.simulate(...)` even if the `obs` is still
+            referenced.
+
+            See :ref:`danger-env-ownership` (first danger block). 
+            
+            This caused issue https://github.com/rte-france/Grid2Op/issues/568 for example.
+             
         Examples
         --------
         A typical use might look like

--- a/grid2op/Runner/runner.py
+++ b/grid2op/Runner/runner.py
@@ -1137,6 +1137,7 @@ class Runner(object):
                 returned list are not necessarily sorted by this value)
               - "cum_reward" the cumulative reward obtained by the :attr:`Runner.Agent` on this episode i
               - "nb_time_step": the number of time steps played in this episode.
+              - "total_step": the total number of time steps possible in this episode.
               - "episode_data" : [Optional] The :class:`EpisodeData` corresponding to this episode run only
                 if `add_detailed_output=True`
               - "add_nb_highres_sim": [Optional] The estimated number of calls to high resolution simulator made

--- a/grid2op/Space/GridObjects.py
+++ b/grid2op/Space/GridObjects.py
@@ -650,70 +650,8 @@ class GridObjects:
 
     @classmethod
     def _clear_class_attribute(cls):
-        cls.glop_version = grid2op.__version__
-        cls._PATH_ENV = None
-
-        cls.SUB_COL = 0
-        cls.LOA_COL = 1
-        cls.GEN_COL = 2
-        cls.LOR_COL = 3
-        cls.LEX_COL = 4
-        cls.STORAGE_COL = 5
-
-        cls.attr_list_vect = None
-        cls.attr_list_set = {}
-        cls.attr_list_json = []
-        cls.attr_nan_list_set = set()
-
-        # class been init
-        cls._IS_INIT = False
-
-        # name of the objects
-        cls.env_name = "unknown"
-        cls.name_load = None
-        cls.name_gen = None
-        cls.name_line = None
-        cls.name_sub = None
-        cls.name_storage = None
-
-        cls.n_gen = -1
-        cls.n_load = -1
-        cls.n_line = -1
-        cls.n_sub = -1
-        cls.n_storage = -1
-
-        cls.sub_info = None
-        cls.dim_topo = -1
-
-        # to which substation is connected each element
-        cls.load_to_subid = None
-        cls.gen_to_subid = None
-        cls.line_or_to_subid = None
-        cls.line_ex_to_subid = None
-        cls.storage_to_subid = None
-
-        # which index has this element in the substation vector
-        cls.load_to_sub_pos = None
-        cls.gen_to_sub_pos = None
-        cls.line_or_to_sub_pos = None
-        cls.line_ex_to_sub_pos = None
-        cls.storage_to_sub_pos = None
-
-        # which index has this element in the topology vector
-        cls.load_pos_topo_vect = None
-        cls.gen_pos_topo_vect = None
-        cls.line_or_pos_topo_vect = None
-        cls.line_ex_pos_topo_vect = None
-        cls.storage_pos_topo_vect = None
-
-        # "convenient" way to retrieve information of the grid
-        cls.grid_objects_types = None
-        # to which substation each element of the topovect is connected
-        cls._topo_vect_to_sub = None
-
-        # list of attribute to convert it from/to a vector
-        cls._vectorized = None
-
+        cls.shunts_data_available = False
+        
         # for redispatching / unit commitment
         cls._li_attr_disp = [
             "gen_type",
@@ -744,56 +682,9 @@ class GridObjects:
             float,
             bool,
         ]
-
-        # redispatch data, not available in all environment
-        cls.redispatching_unit_commitment_availble = False
-        cls.gen_type = None
-        cls.gen_pmin = None
-        cls.gen_pmax = None
-        cls.gen_redispatchable = None
-        cls.gen_max_ramp_up = None
-        cls.gen_max_ramp_down = None
-        cls.gen_min_uptime = None
-        cls.gen_min_downtime = None
-        cls.gen_cost_per_MW = None  # marginal cost (in currency / (power.step) and not in $/(MW.h) it would be $ / (MW.5mins) )
-        cls.gen_startup_cost = None  # start cost (in currency)
-        cls.gen_shutdown_cost = None  # shutdown cost (in currency)
-        cls.gen_renewable = None
-
-        # storage unit static data
-        cls.storage_type = None
-        cls.storage_Emax = None
-        cls.storage_Emin = None
-        cls.storage_max_p_prod = None
-        cls.storage_max_p_absorb = None
-        cls.storage_marginal_cost = None
-        cls.storage_loss = None
-        cls.storage_charging_efficiency = None
-        cls.storage_discharging_efficiency = None
-
-        # grid layout
-        cls.grid_layout = None
-
-        # shunt data, not available in every backend
-        cls.shunts_data_available = False
-        cls.n_shunt = None
-        cls.name_shunt = None
-        cls.shunt_to_subid = None
-
-        # alarm / alert
-        cls.assistant_warning_type = None
         
-        # alarms
-        cls.dim_alarms = 0
-        cls.alarms_area_names = []
-        cls.alarms_lines_area = {}
-        cls.alarms_area_lines = []
-
-        # alerts
-        cls.dim_alerts = 0
-        cls.alertable_line_names = []
-        cls.alertable_line_ids = []
-
+        cls._clear_grid_dependant_class_attributes()
+        
     @classmethod
     def _clear_grid_dependant_class_attributes(cls):
         cls.glop_version = grid2op.__version__
@@ -856,10 +747,10 @@ class GridObjects:
         cls.grid_objects_types = None
         # to which substation each element of the topovect is connected
         cls._topo_vect_to_sub = None
-                
+
         # list of attribute to convert it from/to a vector
         cls._vectorized = None
-        
+
         # redispatch data, not available in all environment
         cls.redispatching_unit_commitment_availble = False
         cls.gen_type = None
@@ -885,7 +776,15 @@ class GridObjects:
         cls.storage_loss = None
         cls.storage_charging_efficiency = None
         cls.storage_discharging_efficiency = None
-        
+
+        # grid layout
+        cls.grid_layout = None
+
+        # shunt data, not available in every backend
+        cls.n_shunt = None
+        cls.name_shunt = None
+        cls.shunt_to_subid = None
+
         # alarm / alert
         cls.assistant_warning_type = None
         
@@ -899,11 +798,6 @@ class GridObjects:
         cls.dim_alerts = 0
         cls.alertable_line_names = []
         cls.alertable_line_ids = []
-        
-        # shunt data, not available in every backend
-        cls.n_shunt = None
-        cls.name_shunt = None
-        cls.shunt_to_subid = None
         
     @classmethod
     def _update_value_set(cls):

--- a/grid2op/__init__.py
+++ b/grid2op/__init__.py
@@ -11,7 +11,7 @@
 Grid2Op
 
 """
-__version__ = '1.9.8.dev0'
+__version__ = '1.9.8.dev1'
 
 __all__ = [
     "Action",
@@ -43,6 +43,7 @@ __all__ = [
     "update_env",
     "make",
 ]
+
 
 
 from grid2op.MakeEnv import  (make,

--- a/grid2op/__init__.py
+++ b/grid2op/__init__.py
@@ -11,7 +11,7 @@
 Grid2Op
 
 """
-__version__ = '1.9.7'
+__version__ = '1.9.8.dev0'
 
 __all__ = [
     "Action",

--- a/grid2op/command_line.py
+++ b/grid2op/command_line.py
@@ -61,7 +61,7 @@ def replay():
 
 def testinstall():
     """
-    Performs aperforms basic tests to make sure grid2op is properly installed and working.
+    Performs basic tests to make sure grid2op is properly installed and working.
 
     It's not because these tests pass that grid2op will be fully functional however.
     """
@@ -76,15 +76,25 @@ def testinstall():
                 os.path.join(this_directory, "tests"), pattern=file_name
             )
         )
-    results = unittest.TextTestResult(stream=sys.stderr, descriptions=True, verbosity=1)
+        
+    def fun(first=None, *args, **kwargs):
+        if first is not None:
+            sys.stderr.write(first, *args, **kwargs)
+        sys.stderr.write("\n")
+    sys.stderr.writeln = fun
+    results = unittest.TextTestResult(stream=sys.stderr,
+                                      descriptions=True,
+                                      verbosity=2)
     test_suite.run(results)
     if results.wasSuccessful():
-        sys.exit(0)
+        return 0
     else:
-        for _, str_ in results.errors:
-            print(str_)
-            print("-------------------------\n")
-        for _, str_ in results.failures:
-            print(str_)
-            print("-------------------------\n")
+        print("\n")
+        results.printErrors()
+        # for _, str_ in results.errors:
+        #     print(str_)
+        #     print("-------------------------\n")
+        # for _, str_ in results.failures:
+        #     print(str_)
+        #     print("-------------------------\n")
         raise RuntimeError("Test not successful !")

--- a/grid2op/gym_compat/box_gym_actspace.py
+++ b/grid2op/gym_compat/box_gym_actspace.py
@@ -77,14 +77,14 @@ class __AuxBoxGymActSpace:
 
     .. code-block:: python
 
-        gym_env.observation_space = BoxGymActSpace(env.observation_space,
+        gym_env.action_space = BoxGymActSpace(env.action_space,
                                                    attr_to_keep=['redispatch', "curtail"])
 
     You can also apply some basic transformation to the attribute of the action. This can be done with:
 
     .. code-block:: python
 
-        gym_env.observation_space = BoxGymActSpace(env.observation_space,
+        gym_env.action_space = BoxGymActSpace(env.action_space,
                                                    attr_to_keep=['redispatch', "curtail"],
                                                    multiply={"redispatch": env.gen_max_ramp_up},
                                                    add={"redispatch": 0.5 * env.gen_max_ramp_up})
@@ -654,7 +654,7 @@ class __AuxBoxGymActSpace:
                 both_finite &= curr_high > curr_low
 
                 if (~both_finite).any():
-                    warnings.warn(f"The normalization of attribute \"{both_finite}\" cannot be performed entirely as "
+                    warnings.warn(f"The normalization of attribute \"{attr_tmp}\" cannot be performed entirely as "
                                   f"there are some non finite value, or `high == `low` "
                                   f"for some components.")
                     

--- a/grid2op/gym_compat/box_gym_obsspace.py
+++ b/grid2op/gym_compat/box_gym_obsspace.py
@@ -908,7 +908,7 @@ class __AuxBoxGymObsSpace:
                 both_finite &= curr_high > curr_low
 
                 if (~both_finite).any():
-                    warnings.warn(f"The normalization of attribute \"{both_finite}\" cannot be performed entirely as "
+                    warnings.warn(f"The normalization of attribute \"{attr_nm}\" cannot be performed entirely as "
                                   f"there are some non finite value, or `high == `low` "
                                   f"for some components.")
                     

--- a/grid2op/gym_compat/gymenv.py
+++ b/grid2op/gym_compat/gymenv.py
@@ -154,15 +154,17 @@ class __AuxGymEnv:
         # used for gym > 0.26
         if self._shuffle_chronics and isinstance(
             self.init_env.chronics_handler.real_data, Multifolder
-        ):
+        ) and (options is not None and "time serie id" not in options):
             self.init_env.chronics_handler.sample_next_chronics()
         
-        super().reset(seed=seed)    
+        super().reset(seed=seed)  # seed gymnasium env
         if seed is not None:
             self._aux_seed_spaces()
             seed, next_seed, underlying_env_seeds = self._aux_seed_g2op(seed)
-            
-        g2op_obs = self.init_env.reset()
+        
+        # we don't seed grid2op with reset as it is done
+        # earlier
+        g2op_obs = self.init_env.reset(seed=None, options=options)
         gym_obs = self.observation_space.to_gym(g2op_obs)
             
         chron_id = self.init_env.chronics_handler.get_id()

--- a/grid2op/simulator/simulator.py
+++ b/grid2op/simulator/simulator.py
@@ -339,7 +339,7 @@ class Simulator(object):
         scale_objective = np.round(scale_objective, decimals=4)
 
         tmp_zeros = np.zeros((1, nb_dispatchable), dtype=float)
-
+        
         # wrap everything into the proper scipy form
         def target(actual_dispatchable):
             # define my real objective
@@ -407,7 +407,7 @@ class Simulator(object):
                 denom_adjust = 1.0
             x0[can_adjust] = -init_sum / (weights[can_adjust] * denom_adjust)
 
-        res = f(x0)
+        res = f(x0.astype(float))
         if res.success:
             return res.x
         else:

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -177,8 +177,8 @@ class BaseTestLoadingCase(MakeBackend):
 
         assert np.all(backend.get_topo_vect() == np.ones(np.sum(backend.sub_info)))
 
-        conv = backend.runpf()
-        assert conv, "powerflow diverge it is not supposed to!"
+        conv, *_  = backend.runpf()
+        assert conv, f"powerflow diverge it is not supposed to! Error {_}"
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
@@ -199,8 +199,8 @@ class BaseTestLoadingCase(MakeBackend):
             backend.load_grid(path_matpower, case_file)
         type(backend).set_env_name("TestLoadingCase_env2_test_assert_grid_correct")
         backend.assert_grid_correct()
-        conv = backend.runpf()
-        assert conv, "powerflow diverge it is not supposed to!"
+        conv, *_  = backend.runpf()
+        assert conv, f"powerflow diverge it is not supposed to! Error {_}"
         backend.assert_grid_correct_after_powerflow()
 
 
@@ -262,8 +262,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
 
     def test_runpf_dc(self):
         self.skip_if_needed()
-        conv = self.backend.runpf(is_dc=True)
-        assert conv
+        conv, *_  = self.backend.runpf(is_dc=True)
+        assert conv, f"powerflow diverge with error {_}"
         true_values_dc = np.array(
             [
                 147.83859556,
@@ -317,7 +317,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
                 2.80741759e01,
             ]
         )
-        conv = self.backend.runpf(is_dc=False)
+        conv, *_  = self.backend.runpf(is_dc=False)
+        assert conv, f"powerflow diverge with error {_}"
         assert conv
         p_or, *_ = self.backend.lines_or_info()
         assert self.compare_vect(p_or, true_values_ac)
@@ -325,8 +326,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
     def test_voltage_convert_powerlines(self):
         self.skip_if_needed()
         # i have the correct voltages in powerlines if the formula to link mw, mvar, kv and amps is correct
-        conv = self.backend.runpf(is_dc=False)
-        assert conv, "powerflow diverge at loading"
+        conv, *_  = self.backend.runpf(is_dc=False)
+        assert conv, f"powerflow diverge at loading with error {_}"
 
         p_or, q_or, v_or, a_or = self.backend.lines_or_info()
         a_th = np.sqrt(p_or**2 + q_or**2) * 1e3 / (np.sqrt(3) * v_or)
@@ -341,8 +342,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         # i have the right voltages to generators and load, if it's the same as the voltage (correct from the above test)
         # of the powerline connected to it.
 
-        conv = self.backend.runpf(is_dc=False)
-        assert conv, "powerflow diverge at loading"
+        conv, *_  = self.backend.runpf(is_dc=False)
+        assert conv, f"powerflow diverge at loading with error {_}"
         load_p, load_q, load_v = self.backend.loads_info()
         gen_p, gen__q, gen_v = self.backend.generators_info()
         p_or, q_or, v_or, a_or = self.backend.lines_or_info()
@@ -384,33 +385,37 @@ class BaseTestLoadingBackendFunc(MakeBackend):
                 continue
             assert False, "generator {} has not been checked".format(g_id)
 
-    def test_copy(self):
+    def test_copy_ac(self, is_dc=False):
         self.skip_if_needed()
-        conv = self.backend.runpf(is_dc=False)
-        assert conv, "powerflow diverge at loading"
+        conv, *_ = self.backend.runpf(is_dc=is_dc)
+        assert conv, f"powerflow diverge at loading with error {_}"
         l_id = 3
 
         p_or_orig, *_ = self.backend.lines_or_info()
-        adn_backend_cpy = self.backend.copy()
+        backend_cpy = self.backend.copy()
 
         self.backend._disconnect_line(l_id)
-        conv = self.backend.runpf(is_dc=False)
-        assert conv
-        conv2 = adn_backend_cpy.runpf(is_dc=False)
-        assert conv2
+        conv, *_ = self.backend.runpf(is_dc=is_dc)
+        assert conv, f"original backend diverged with error {_}"
+        conv2 = backend_cpy.runpf(is_dc=is_dc)
+        assert conv2, f"copied backend diverged with error {_}"
         p_or_ref, *_ = self.backend.lines_or_info()
-        p_or, *_ = adn_backend_cpy.lines_or_info()
+        p_or, *_ = backend_cpy.lines_or_info()
         assert self.compare_vect(
             p_or_orig, p_or
         ), "the copied object affects its original 'parent'"
         assert (
             np.abs(p_or_ref[l_id]) <= self.tol_one
-        ), "powerline {} has not been disconnected".format(l_id)
+        ), "powerline {} has not been disconnected in orig backend".format(l_id)
+
+    def test_copy_dc(self):
+        self.skip_if_needed()
+        self.test_copy_ac(True)
 
     def test_copy2(self):
         self.skip_if_needed()
         self.backend._disconnect_line(8)
-        conv = self.backend.runpf(is_dc=False)
+        conv, *_  = self.backend.runpf(is_dc=False)
         p_or_orig, *_ = self.backend.lines_or_info()
 
         adn_backend_cpy = self.backend.copy()
@@ -520,12 +525,12 @@ class BaseTestLoadingBackendFunc(MakeBackend):
                 5.77869057,
             ]
         )
-        conv = self.backend.runpf(is_dc=True)
-        assert conv
+        conv, *_  = self.backend.runpf(is_dc=True)
+        assert conv, f"error {_}"
         p_or_orig, q_or_orig, *_ = self.backend.lines_or_info()
         assert np.all(q_or_orig == 0.0), "in dc mode all q must be zero"
-        conv = self.backend.runpf(is_dc=False)
-        assert conv
+        conv, *_  = self.backend.runpf(is_dc=False)
+        assert conv, f"error {_}"
         p_or_orig, q_or_orig, *_ = self.backend.lines_or_info()
         assert self.compare_vect(q_or_orig, true_values_ac)
 
@@ -567,11 +572,11 @@ class BaseTestLoadingBackendFunc(MakeBackend):
                 continue
             backend_cpy = self.backend.copy()
             backend_cpy._disconnect_line(i)
-            conv = backend_cpy.runpf()
+            conv, *_  = backend_cpy.runpf()
             assert (
                 conv
-            ), "Power flow computation does not converge if line {} is removed".format(
-                i
+            ), "Power flow computation does not converge if line {} is removed with error ".format(
+                i, _
             )
             flows = backend_cpy.get_line_status()
             assert not flows[i]
@@ -579,7 +584,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
 
     def test_donothing_action(self):
         self.skip_if_needed()
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"error {_}"
         init_flow = self.backend.get_line_flow()
         init_lp, *_ = self.backend.loads_info()
         init_gp, *_ = self.backend.generators_info()
@@ -596,8 +602,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         # assert self.compare_vect(init_gp, after_gp)  # check i didn't modify the generators  # TODO here !!! problem with steady state P=C+L
         assert np.all(init_ls == after_ls)  # check i didn't disconnect any powerlines
 
-        conv = self.backend.runpf()
-        assert conv, "Cannot perform a powerflow after doing nothing"
+        conv, *_  = self.backend.runpf()
+        assert conv, f"Cannot perform a powerflow after doing nothing with error {_}"
         after_flow = self.backend.get_line_flow()
         assert self.compare_vect(init_flow, after_flow)
 
@@ -608,8 +614,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         # also multiply by 2
 
         # i set up the stuff to have exactly 0 losses
-        conv = self.backend.runpf(is_dc=True)
-        assert conv, "powergrid diverge after loading (even in DC)"
+        conv, *_  = self.backend.runpf(is_dc=True)
+        assert conv, f"powergrid diverge after loading (even in DC) with error {_}"
         init_flow, *_ = self.backend.lines_or_info()
         init_lp, init_l_q, *_ = self.backend.loads_info()
         init_gp, *_ = self.backend.generators_info()
@@ -623,7 +629,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf(is_dc=True)
+        conv, *_  = self.backend.runpf(is_dc=True)
+        assert conv, f"powergrid diverge with error {_}"
         # now the system has exactly 0 losses (ie sum load = sum gen)
 
         # i check that if i divide by 2, then everything is divided by 2
@@ -641,8 +648,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf(is_dc=True)
-        assert conv, "Cannot perform a powerflow after doing nothing"
+        conv, *_  = self.backend.runpf(is_dc=True)
+        assert conv, "Cannot perform a powerflow after doing nothing (dc)"
 
         after_lp, after_lq, *_ = self.backend.loads_info()
         after_gp, *_ = self.backend.generators_info()
@@ -656,10 +663,10 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         # i'm in DC mode, i can't check for reactive values...
         assert (
             np.max(np.abs(p_subs)) <= self.tolvect
-        ), "problem with active values, at substation"
+        ), "problem with active values, at substation (kirchoff for DC)"
         assert (
             np.max(np.abs(p_bus.flatten())) <= self.tolvect
-        ), "problem with active values, at a bus"
+        ), "problem with active values, at a bus (kirchoff for DC)"
 
         assert self.compare_vect(
             new_pp, after_gp
@@ -673,8 +680,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
 
     def test_apply_action_prod_v(self):
         self.skip_if_needed()
-        conv = self.backend.runpf(is_dc=False)
-        assert conv, "powergrid diverge after loading"
+        conv, *_  = self.backend.runpf(is_dc=False)
+        assert conv, f"powergrid diverge after loading with error {_}"
         prod_p_init, prod_q_init, prod_v_init = self.backend.generators_info()
         ratio = 1.05
         action = self.action_env(
@@ -683,8 +690,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf(is_dc=False)
-        assert conv, "Cannot perform a powerflow after modifying the powergrid"
+        conv, *_  = self.backend.runpf(is_dc=False)
+        assert conv, f"Cannot perform a powerflow after modifying the powergrid with error {_}"
 
         prod_p_after, prod_q_after, prod_v_after = self.backend.generators_info()
         assert self.compare_vect(
@@ -694,7 +701,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
     def test_apply_action_maintenance(self):
         self.skip_if_needed()
         # retrieve some initial data to be sure only a subpart of the _grid is modified
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         init_lp, *_ = self.backend.loads_info()
         init_gp, *_ = self.backend.generators_info()
 
@@ -709,8 +717,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         self.backend.apply_action(bk_action)
 
         # compute a load flow an performs more tests
-        conv = self.backend.runpf()
-        assert conv, "Power does not converge if line {} is removed".format(19)
+        conv, *_ = self.backend.runpf()
+        assert conv, "Power does not converge if line {} is removed with error {}".format(19, _)
 
         # performs basic check
         after_lp, *_ = self.backend.loads_info()
@@ -728,8 +736,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
 
     def test_apply_action_hazard(self):
         self.skip_if_needed()
-        conv = self.backend.runpf()
-        assert conv, "powerflow did not converge at iteration 0"
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow did not converge at iteration 0, with error {_}"
         init_lp, *_ = self.backend.loads_info()
         init_gp, *_ = self.backend.generators_info()
 
@@ -743,8 +751,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         self.backend.apply_action(bk_action)
 
         # compute a load flow an performs more tests
-        conv = self.backend.runpf()
-        assert conv, "Power does not converge if line {} is removed".format(19)
+        conv, *_  = self.backend.runpf()
+        assert conv, "Power does not converge if line {} is removed with error {}".format(19, _)
 
         # performs basic check
         after_lp, *_ = self.backend.loads_info()
@@ -759,7 +767,8 @@ class BaseTestLoadingBackendFunc(MakeBackend):
     def test_apply_action_disconnection(self):
         self.skip_if_needed()
         # retrieve some initial data to be sure only a subpart of the _grid is modified
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         init_lp, *_ = self.backend.loads_info()
         init_gp, *_ = self.backend.generators_info()
 
@@ -779,10 +788,10 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         self.backend.apply_action(bk_action)
 
         # compute a load flow an performs more tests
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
         assert (
             conv
-        ), "Powerflow does not converge if lines {} and {} are removed".format(17, 19)
+        ), "Powerflow does not converge if lines {} and {} are removed with error {}".format(17, 19, _)
 
         # performs basic check
         after_lp, *_ = self.backend.loads_info()
@@ -858,7 +867,8 @@ class BaseTestTopoAction(MakeBackend):
     def test_get_topo_vect_speed(self):
         # retrieve some initial data to be sure only a subpart of the _grid is modified
         self.skip_if_needed()
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         init_amps_flow = self.backend.get_line_flow()
 
         # check that maintenance vector is properly taken into account
@@ -869,8 +879,8 @@ class BaseTestTopoAction(MakeBackend):
         bk_action += action
         # apply the action here
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf()
-        assert conv
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         after_amps_flow = self.backend.get_line_flow()
 
         topo_vect = self.backend.get_topo_vect()
@@ -940,7 +950,8 @@ class BaseTestTopoAction(MakeBackend):
     def test_topo_set1sub(self):
         # retrieve some initial data to be sure only a subpart of the _grid is modified
         self.skip_if_needed()
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         init_amps_flow = self.backend.get_line_flow()
 
         # check that maintenance vector is properly taken into account
@@ -952,8 +963,8 @@ class BaseTestTopoAction(MakeBackend):
 
         # apply the action here
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf()
-        assert conv
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         after_amps_flow = self.backend.get_line_flow()
 
         topo_vect = self.backend.get_topo_vect()
@@ -1037,7 +1048,8 @@ class BaseTestTopoAction(MakeBackend):
     def test_topo_change1sub(self):
         # check that switching the bus of 3 object is equivalent to set them to bus 2 (as above)
         self.skip_if_needed()
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         init_amps_flow = self.backend.get_line_flow()
 
         # check that maintenance vector is properly taken into account
@@ -1050,8 +1062,8 @@ class BaseTestTopoAction(MakeBackend):
         self.backend.apply_action(bk_action)
 
         # run the powerflow
-        conv = self.backend.runpf()
-        assert conv
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         after_amps_flow = self.backend.get_line_flow()
 
         topo_vect = self.backend.get_topo_vect()
@@ -1111,7 +1123,8 @@ class BaseTestTopoAction(MakeBackend):
         # check that switching the bus of 3 object is equivalent to set them to bus 2 (as above)
         # and that setting it again is equivalent to doing nothing
         self.skip_if_needed()
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with , error: {_}"
         init_amps_flow = copy.deepcopy(self.backend.get_line_flow())
 
         # check that maintenance vector is properly taken into account
@@ -1123,9 +1136,9 @@ class BaseTestTopoAction(MakeBackend):
 
         # apply the action here
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf()
+        conv, *_  = self.backend.runpf()
         bk_action.reset()
-        assert conv
+        assert conv, f"powerflow diverge with , error: {_}"
         after_amps_flow = self.backend.get_line_flow()
 
         topo_vect = self.backend.get_topo_vect()
@@ -1186,8 +1199,8 @@ class BaseTestTopoAction(MakeBackend):
 
         # apply the action here
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf()
-        assert conv
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge with error: {_}"
 
         after_amps_flow = self.backend.get_line_flow()
         assert self.compare_vect(after_amps_flow, init_amps_flow)
@@ -1214,8 +1227,8 @@ class BaseTestTopoAction(MakeBackend):
 
         # apply the action here
         self.backend.apply_action(bk_action)
-        conv = self.backend.runpf()
-        assert conv, "powerflow diverge it should not"
+        conv, *_  = self.backend.runpf()
+        assert conv, f"powerflow diverge it should not, error: {_}"
 
         # check the _grid is correct
         topo_vect = self.backend.get_topo_vect()
@@ -1684,8 +1697,8 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             self.backend.load_grid(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
-        conv = self.backend.runpf()
-        assert conv, "powerflow should converge at loading"
+        conv, *_ = self.backend.runpf()
+        assert conv, f"powerflow should converge at loading, error: {_}"
         lines_flows_init = self.backend.get_line_flow()
         thermal_limit = 10 * lines_flows_init
         thermal_limit[self.id_first_line_disco] = (
@@ -1728,8 +1741,8 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             self.backend.load_grid(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
-        conv = self.backend.runpf()
-        assert conv, "powerflow should converge at loading"
+        conv, *_ = self.backend.runpf()
+        assert conv, f"powerflow should converge at loading, error: {_}"
         lines_flows_init = self.backend.get_line_flow()
 
         thermal_limit = 10 * lines_flows_init

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -2741,7 +2741,7 @@ class BaseIssuesTest(MakeBackend):
             }
         )
         obs, reward, done, info = env.step(action)
-        assert not done
+        assert not done, f"Episode should not have ended here, error : {info['exception']}"
         assert obs.line_status[LINE_ID] == False
         assert obs.topo_vect[obs.line_or_pos_topo_vect[LINE_ID]] == -1
         assert obs.topo_vect[obs.line_ex_pos_topo_vect[LINE_ID]] == -1

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -74,7 +74,7 @@ class BaseTestNames(MakeBackend):
     
     def test_properNames(self):
         self.skip_if_needed()
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         path = self.get_path()
 
         with warnings.catch_warnings():
@@ -97,7 +97,7 @@ class BaseTestLoadingCase(MakeBackend):
         return "test_case14.json"
     
     def test_load_file(self):
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         path_matpower = self.get_path()
         case_file = self.get_casefile()
         with warnings.catch_warnings():
@@ -191,7 +191,7 @@ class BaseTestLoadingCase(MakeBackend):
             assert np.max(np.abs(q_bus.flatten())) <= self.tolvect
 
     def test_assert_grid_correct(self):
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         path_matpower = self.get_path()
         case_file = self.get_casefile()
         with warnings.catch_warnings():
@@ -212,7 +212,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         return "test_case14.json"
     
     def setUp(self):
-        self.backend = self.make_backend()
+        self.backend = self.make_backend_with_glue_code()
         self.path_matpower = self.get_path()
         self.case_file = self.get_casefile()
         with warnings.catch_warnings():
@@ -813,7 +813,7 @@ class BaseTestTopoAction(MakeBackend):
         return "test_case14.json"
     
     def setUp(self):
-        self.backend = self.make_backend()
+        self.backend = self.make_backend_with_glue_code()
         self.path_matpower = self.get_path()
         self.case_file = self.get_casefile()
         with warnings.catch_warnings():
@@ -1422,13 +1422,13 @@ class BaseTestTopoAction(MakeBackend):
             env = grid2op.make(
                 "educ_case14_storage",
                 test=True,
-                backend=self.make_backend(),
+                backend=self.make_backend_with_glue_code(),
                 _add_to_name=type(self).__name__
             )
             env2 = grid2op.make(
                 "educ_case14_storage",
                 test=True,
-                backend=self.make_backend(),
+                backend=self.make_backend_with_glue_code(),
                 _add_to_name=type(self).__name__
             )
         obs, *_ = env.step(env.action_space({"set_storage": [-1.0, 1.0]}))
@@ -1453,7 +1453,7 @@ class BaseTestTopoAction(MakeBackend):
             env = grid2op.make(
                 "rte_case14_realistic",
                 test=True,
-                backend=self.make_backend(),
+                backend=self.make_backend_with_glue_code(),
                 _add_to_name=type(self).__name__
             )
 
@@ -1559,8 +1559,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
         return PATH_DATA_TEST
 
     def setUp(self):
-        self.backend = self.make_backend(detailed_infos_for_cascading_failures=True)
-        type(self.backend)._clear_grid_dependant_class_attributes()
+        self.backend = self.make_backend_with_glue_code(detailed_infos_for_cascading_failures=True)
         self.path_matpower = self.get_path()
         self.case_file = self.get_casefile()
         with warnings.catch_warnings():
@@ -1885,12 +1884,11 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_set_bus(self):
         self.skip_if_needed()
         # print("test_set_bus")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make("rte_case14_realistic", test=True, backend=backend,
-                       _add_to_name=type(self).__name__)
+                               _add_to_name=type(self).__name__)
         env.reset()
         action = env.action_space({"set_bus": {"lines_or_id": [(17, 2)]}})
         obs, reward, done, info = env.step(action)
@@ -1901,8 +1899,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_change_bus(self):
         self.skip_if_needed()
         # print("test_change_bus")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make("rte_case14_realistic", test=True, backend=backend,
@@ -1916,8 +1913,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_change_bustwice(self):
         self.skip_if_needed()
         # print("test_change_bustwice")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make("rte_case14_realistic", test=True, backend=backend,
@@ -1938,8 +1934,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_isolate_load(self):
         self.skip_if_needed()
         # print("test_isolate_load")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make("rte_case14_realistic", test=True, backend=backend,
@@ -1951,8 +1946,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_reco_disco_bus(self):
         self.skip_if_needed()
         # print("test_reco_disco_bus")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env_case1 = grid2op.make(
@@ -1978,8 +1972,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_reco_disco_bus2(self):
         self.skip_if_needed()
         # print("test_reco_disco_bus2")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env_case2 = grid2op.make(
@@ -2005,8 +1998,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_reco_disco_bus3(self):
         self.skip_if_needed()
         # print("test_reco_disco_bus3")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env_case2 = grid2op.make(
@@ -2030,8 +2022,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_reco_disco_bus4(self):
         self.skip_if_needed()
         # print("test_reco_disco_bus4")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env_case2 = grid2op.make(
@@ -2055,8 +2046,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
     def test_reco_disco_bus5(self):
         self.skip_if_needed()
         # print("test_reco_disco_bus5")
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env_case2 = grid2op.make(
@@ -2078,7 +2068,7 @@ class BaseTestChangeBusAffectRightBus(MakeBackend):
 class BaseTestShuntAction(MakeBackend):
     def test_shunt_ambiguous_id_incorrect(self):
         self.skip_if_needed()
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             with grid2op.make(
@@ -2094,8 +2084,8 @@ class BaseTestShuntAction(MakeBackend):
 
     def test_shunt_effect(self):
         self.skip_if_needed()
-        backend1 = self.make_backend()
-        backend2 = self.make_backend()
+        backend1 = self.make_backend_with_glue_code()
+        backend2 = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env_ref = grid2op.make(
@@ -2170,9 +2160,8 @@ class BaseTestShuntAction(MakeBackend):
 
 class BaseTestResetEqualsLoadGrid(MakeBackend):
     def setUp(self):
-        backend1 = self.make_backend()
-        backend2 = self.make_backend()
-        type(backend1)._clear_grid_dependant_class_attributes()
+        backend1 = self.make_backend_with_glue_code()
+        backend2 = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env1 = grid2op.make("rte_case5_example", test=True, backend=backend1, _add_to_name=type(self).__name__)
@@ -2304,8 +2293,7 @@ class BaseTestResetEqualsLoadGrid(MakeBackend):
 
     def test_combined_changes(self):
         # Unlimited sub changes
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         params = grid2op.Parameters.Parameters()
         params.MAX_SUB_CHANGED = 999
 
@@ -2376,8 +2364,7 @@ class BaseTestResetEqualsLoadGrid(MakeBackend):
 class BaseTestVoltageOWhenDisco(MakeBackend):
     def test_this(self):
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             with grid2op.make("rte_case14_realistic", test=True, backend=backend, _add_to_name=type(self).__name__) as env:
@@ -2392,8 +2379,7 @@ class BaseTestVoltageOWhenDisco(MakeBackend):
 class BaseTestChangeBusSlack(MakeBackend):
     def test_change_slack_case14(self):
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make("rte_case14_realistic", test=True, backend=backend, _add_to_name=type(self).__name__)
@@ -2439,8 +2425,7 @@ class BaseTestStorageAction(MakeBackend):
     def test_there_are_storage(self):
         """test the backend properly loaded the storage units"""
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make("educ_case14_storage", test=True, backend=backend, _add_to_name=type(self).__name__)
@@ -2449,8 +2434,7 @@ class BaseTestStorageAction(MakeBackend):
     def test_storage_action_mw(self):
         """test the actions are properly implemented in the backend"""
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make("educ_case14_storage", test=True, backend=backend, _add_to_name=type(self).__name__)
@@ -2520,8 +2504,7 @@ class BaseTestStorageAction(MakeBackend):
         param = Parameters()
         param.NB_TIMESTEP_COOLDOWN_SUB = 0
         param.NB_TIMESTEP_COOLDOWN_LINE = 0
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make(
@@ -2669,8 +2652,7 @@ class BaseIssuesTest(MakeBackend):
     def test_issue_125(self):
         # https://github.com/rte-france/Grid2Op/issues/125
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env = grid2op.make("rte_case14_realistic", test=True, backend=backend, _add_to_name=type(self).__name__)
@@ -2691,8 +2673,7 @@ class BaseIssuesTest(MakeBackend):
 
     def test_issue_134(self):
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         param = Parameters()
 
         param.NB_TIMESTEP_COOLDOWN_LINE = 0
@@ -2769,8 +2750,7 @@ class BaseIssuesTest(MakeBackend):
 
     def test_issue_134_check_ambiguity(self):
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         param = Parameters()
 
         param.MAX_LINE_STATUS_CHANGED = 9999
@@ -2799,8 +2779,7 @@ class BaseIssuesTest(MakeBackend):
 
     def test_issue_134_withcooldown_forrules(self):
         self.skip_if_needed()
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         param = Parameters()
 
         param.NB_TIMESTEP_COOLDOWN_LINE = 20
@@ -2941,8 +2920,7 @@ class BaseIssuesTest(MakeBackend):
 
     def test_issue_copyenv(self):
         # https://github.com/BDonnot/lightsim2grid/issues/10
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             env1 = grid2op.make("rte_case14_realistic", test=True, backend=backend, _add_to_name=type(self).__name__)
@@ -2954,8 +2932,7 @@ class BaseIssuesTest(MakeBackend):
 
 class BaseStatusActions(MakeBackend):
     def _make_my_env(self):
-        backend = self.make_backend()
-        type(backend)._clear_grid_dependant_class_attributes()
+        backend = self.make_backend_with_glue_code()
         param = Parameters()
         param.NB_TIMESTEP_COOLDOWN_LINE = 0
         param.NB_TIMESTEP_COOLDOWN_SUB = 0

--- a/grid2op/tests/BaseRedispTest.py
+++ b/grid2op/tests/BaseRedispTest.py
@@ -33,7 +33,7 @@ class BaseTestRedispatch(MakeBackend):
     def setUp(self):
         super().setUp()
         # powergrid
-        self.backend = self.make_backend()
+        self.backend = self.make_backend_with_glue_code()
         self.path_matpower = self.get_path()
         self.case_file = self.get_casefile()
 
@@ -374,7 +374,7 @@ class BaseTestRedispatchChangeNothingEnvironment(MakeBackend):
     def setUp(self):
         super().setUp()
         # powergrid
-        self.backend = self.make_backend()
+        self.backend = self.make_backend_with_glue_code()
         self.path_matpower = self.get_path()
         self.case_file = self.get_casefile()
 
@@ -476,7 +476,7 @@ class BaseTestRedispTooLowHigh(MakeBackend):
     # test bug reported in issues https://github.com/rte-france/Grid2Op/issues/44
     def setUp(self) -> None:
         super().setUp()
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make("rte_case14_redisp",
@@ -574,7 +574,7 @@ class BaseTestDispatchRampingIllegalETC(MakeBackend):
     def setUp(self):
         super().setUp()
         # powergrid
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make("rte_case14_test", test=True, backend=backend,
@@ -842,7 +842,7 @@ class BaseTestLoadingAcceptAlmostZeroSumRedisp(MakeBackend):
     def setUp(self):
         super().setUp()
         # powergrid
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make("rte_case14_test", test=True, backend=backend,

--- a/grid2op/tests/__init__.py
+++ b/grid2op/tests/__init__.py
@@ -5,5 +5,3 @@
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
-
-__all__ = ["BaseBackendTest", "BaseIssuesTest", "BaseRedispTest"]

--- a/grid2op/tests/_aux_test_gym_compat.py
+++ b/grid2op/tests/_aux_test_gym_compat.py
@@ -793,9 +793,8 @@ class _AuxTestBoxGymObsSpace:
                 action_class=PlayableAction,
                 _add_to_name=type(self).__name__
             )
-        self.env.seed(0)
-        self.env.reset()  # seed part !
-        self.obs_env = self.env.reset()
+        self.env.reset()
+        self.obs_env = self.env.reset(seed=0, options={"time serie id": 0})
         self.env_gym = self._aux_GymEnv_cls()(self.env)
 
     def test_assert_raises_creation(self):
@@ -888,7 +887,7 @@ class _AuxTestBoxGymObsSpace:
         assert observation_space._attr_to_keep == kept_attr
         assert len(obs_gym) == 17
         # the substract are calibrated so that the maximum is really close to 0
-        assert obs_gym.max() <= 0
+        assert obs_gym.max() <= 0, f"{obs_gym.max()} should be 0."
         assert obs_gym.max() >= -0.5
 
     def test_functs(self):

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -40,7 +40,7 @@ class AAATestBackendAPI(MakeBackend):
 
     def aux_make_backend(self) -> Backend:
         """do not run nor modify ! (used for this test class only)"""
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
         backend.load_grid(self.get_path(), self.get_casefile())
         backend.load_redispacthing_data("tmp")  # pretend there is no generator
         backend.load_storage_data(self.get_path())
@@ -52,7 +52,7 @@ class AAATestBackendAPI(MakeBackend):
     def test_00create_backend(self):
         """Tests the backend can be created (not integrated in a grid2op environment yet)"""
         self.skip_if_needed()
-        backend = self.make_backend()
+        backend = self.make_backend_with_glue_code()
     
     def test_01load_grid(self):
         """Tests the grid can be loaded (supposes that your backend can read the grid.json in educ_case14_storage)*

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -405,7 +405,7 @@ class AAATestBackendAPI(MakeBackend):
         backend.apply_action(bk_act)  # modification of load_p, load_q and gen_p        
         
         res2 = backend.runpf(is_dc=False)
-        assert res2[0], "backend should not have diverge after such a little perturbation"
+        assert res2[0], f"backend should not have diverged after such a little perturbation. It diverges with error {res2[1]}"
         tmp2 = backend.loads_info()
         assert len(tmp) == 3, "loads_info() should return 3 elements: load_p, load_q, load_v (see doc)"
         load_p_after, load_q_after, load_v_after = tmp2 
@@ -428,7 +428,8 @@ class AAATestBackendAPI(MakeBackend):
             bk_act += action
             backend.apply_action(bk_act)  # modification of load_p, load_q and gen_p   
             res_tmp = backend.runpf(is_dc=False)
-            assert res_tmp[0], "backend should not have diverge after such a little perturbation"
+            assert res_tmp[0], (f"backend should not have diverged after such a little perturbation. "
+                                f"It diverges with error {res_tmp[1]} for load {load_id}")
             tmp = backend.loads_info() 
             assert np.abs(tmp[0][load_id] - load_p_init[load_id]) >= delta_mw / 2., f"error when trying to modify load {load_id}: check the consistency between backend.loads_info() and backend.apply_action for load_p"
             assert np.abs(tmp[1][load_id] - load_q_init[load_id]) >= delta_mvar / 2., f"error when trying to modify load {load_id}: check the consistency between backend.loads_info() and backend.apply_action for load_q"
@@ -463,12 +464,16 @@ class AAATestBackendAPI(MakeBackend):
         backend.apply_action(bk_act)  # modification of load_p, load_q and gen_p        
         
         res2 = backend.runpf(is_dc=False)
-        assert res2[0], "backend should not have diverge after such a little perturbation"
+        assert res2[0], f"backend should not have diverged after such a little perturbation. It diverges with error {res2[1]}"
         tmp2 = backend.generators_info()
         assert len(tmp) == 3, "generators_info() should return 3 elements: gen_p, gen_q, gen_v (see doc)"
         gen_p_after, gen_q_after, gen_v_after = tmp2 
-        assert not np.allclose(gen_p_after, gen_p_init), f"gen_p does not seemed to be modified by apply_action when generators are impacted (active value): check `apply_action` for gen_p / prod_p"
-        assert not np.allclose(gen_v_after, gen_v_init), f"gen_v does not seemed to be modified by apply_action when generators are impacted (voltage setpoint value): check `apply_action` for gen_v / prod_v"
+        assert not np.allclose(gen_p_after, gen_p_init), (f"gen_p does not seemed to be modified by apply_action when "
+                                                          "generators are impacted (active value): check `apply_action` "
+                                                          "for gen_p / prod_p")
+        assert not np.allclose(gen_v_after, gen_v_init), (f"gen_v does not seemed to be modified by apply_action when "
+                                                          "generators are impacted (voltage setpoint value): check `apply_action` "
+                                                          "for gen_v / prod_v")
 
         # now a basic check for "one gen at a time"
         # NB this test cannot be done like this for "prod_v" / gen_v because two generators might be connected to the same
@@ -486,7 +491,8 @@ class AAATestBackendAPI(MakeBackend):
             bk_act += action
             backend.apply_action(bk_act)
             res_tmp = backend.runpf(is_dc=False)
-            assert res_tmp[0], "backend should not have diverge after such a little perturbation"
+            assert res_tmp[0], (f"backend should not have diverged after such a little "
+                                f"perturbation. It diverges with error {res_tmp[1]} for gen {gen_id}")
             tmp = backend.generators_info() 
             if np.abs(tmp[0][gen_id] - gen_p_init[gen_id]) <= delta_mw / 2.:
                 # in case of non distributed slack, backend cannot control the generator acting as the slack.
@@ -541,7 +547,8 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action1
         backend.apply_action(bk_act)  # disconnection of line 0 only
         res_disco = backend.runpf(is_dc=False)
-        assert res_disco[0], f"your backend diverge after disconnection of line {line_id}, which should not be the case"
+        #  backend._grid.tell_solver_need_reset() 
+        assert res_disco[0], f"your backend diverges after disconnection of line {line_id}, which should not be the case"
         tmp_or_disco = backend.lines_or_info()
         tmp_ex_disco = backend.lines_ex_info()
         assert not np.allclose(tmp_or_disco[0], p_or), f"p_or does not seemed to be modified by apply_action when a powerline is disconnected (active value): check `apply_action` for line connection disconnection"
@@ -565,7 +572,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action2
         backend.apply_action(bk_act)  # disconnection of line 0 only
         res_disco = backend.runpf(is_dc=False)
-        assert res_disco[0], f"your backend diverge after disconnection of line {line_id}, which should not be the case"
+        assert res_disco[0], f"your backend diverges after disconnection of line {line_id}, which should not be the case"
         tmp_or_reco = backend.lines_or_info()
         tmp_ex_reco = backend.lines_ex_info()
         assert not np.allclose(tmp_or_disco[0], tmp_or_reco[0]), f"p_or does not seemed to be modified by apply_action when a powerline is reconnected (active value): check `apply_action` for line connection reconnection"
@@ -648,7 +655,8 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action1
         backend.apply_action(bk_act)  # everything on busbar 2 at sub 0
         res = backend.runpf(is_dc=False)
-        assert res[0], "Your powerflow has diverged after the loading of the file, which should not happen"
+        assert res[0], (f"Your powerflow has diverged after a topological change at substation {sub_id} with error {res[1]}."
+                        f"\nCheck `apply_action` for topology.")
         
         if not cls.shunts_data_available:
             warnings.warn(f"{type(self).__name__} test_14change_topology: This test is not performed in depth as your backend does not support shunts")
@@ -1080,7 +1088,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
         res = backend.runpf(is_dc=False)  
-        assert not res[0], "It is expected that your backend return `False` in case of non connected grid in AC."                 
+        assert not res[0], f"It is expected that your backend return `(False, _)` in case of non connected grid in AC."                 
         error = res[1]
         assert isinstance(error, Grid2OpException), f"When your backend return `False`, we expect it throws an exception inheriting from Grid2OpException (second return value), backend returned {type(error)}"  
         if not isinstance(error, BackendError):
@@ -1096,7 +1104,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
         res = backend.runpf(is_dc=True)  
-        assert not res[0], "It is expected that your backend throws an exception inheriting from BackendError in case of non connected grid in DC."                 
+        assert not res[0], f"It is expected that your backend return `(False, _)` in case of non connected grid in DC."                    
         error = res[1]
         assert isinstance(error, Grid2OpException), f"When your backend return `False`, we expect it throws an exception inheriting from Grid2OpException (second return value), backend returned {type(error)}"  
         if not isinstance(error, BackendError):
@@ -1125,6 +1133,7 @@ class AAATestBackendAPI(MakeBackend):
         backend.apply_action(bk_act)
         
         res = backend.runpf(is_dc=False)  
+        assert res[0], f"Your backend diverged in AC after a line disconnection, error was {res[1]}"   
         p_or, q_or, v_or, a_or = backend.lines_or_info()
         p_ex, q_ex, v_ex, a_ex = backend.lines_ex_info()
         assert np.allclose(v_or[line_id], 0.), f"v_or should be 0. for disconnected line, but is currently {v_or[line_id]} (AC)" 
@@ -1141,6 +1150,7 @@ class AAATestBackendAPI(MakeBackend):
         backend.apply_action(bk_act)
         
         res = backend.runpf(is_dc=True)  
+        assert res[0],  f"Your backend diverged in DC after a line disconnection, error was {res[1]}"    
         p_or, q_or, v_or, a_or = backend.lines_or_info()
         p_ex, q_ex, v_ex, a_ex = backend.lines_ex_info()
         assert np.allclose(v_or[line_id], 0.), f"v_or should be 0. for disconnected line, but is currently {v_or[line_id]} (DC)" 
@@ -1177,6 +1187,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=False)  
+        assert res[0],  f"Your backend diverged in AC after a shunt disconnection, error was {res[1]}"    
         p_, q_, v_, bus_ = backend.shunt_info()
         assert np.allclose(v_[shunt_id], 0.), f"v should be 0. for disconnected shunt, but is currently {v_[shunt_id]} (AC)" 
         assert bus_[shunt_id] == -1, f"bus_ should be -1 for disconnected shunt, but is currently {bus_[shunt_id]} (AC)" 
@@ -1189,6 +1200,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=True)  
+        assert res[0],  f"Your backend diverged in DC after a shunt disconnection, error was {res[1]}"    
         p_, q_, v_, bus_ = backend.shunt_info()
         assert np.allclose(v_[shunt_id], 0.), f"v should be 0. for disconnected shunt, but is currently {v_[shunt_id]} (DC)" 
         assert bus_[shunt_id] == -1, f"bus_ should be -1 for disconnected shunt, but is currently {bus_[shunt_id]} (DC)" 
@@ -1221,6 +1233,7 @@ class AAATestBackendAPI(MakeBackend):
         backend.apply_action(bk_act)
         
         res = backend.runpf(is_dc=False)  
+        assert res[0],  f"Your backend diverged in AC after a storage disconnection, error was {res[1]}"    
         p_, q_, v_ = backend.storages_info()
         assert np.allclose(v_[storage_id], 0.), f"v should be 0. for disconnected storage, but is currently {v_[storage_id]} (AC)" 
         
@@ -1232,6 +1245,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=True)  
+        assert res[0],  f"Your backend diverged in DC after a storage disconnection, error was {res[1]}"    
         p_, q_, v_ = backend.storages_info()
         assert np.allclose(v_[storage_id], 0.), f"v should be 0. for disconnected storage, but is currently {v_[storage_id]} (AC)" 
     
@@ -1261,7 +1275,8 @@ class AAATestBackendAPI(MakeBackend):
         # backend can be copied
         backend_cpy = backend.copy()
         assert isinstance(backend_cpy, type(backend)), f"backend.copy() is supposed to return an object of the same type as your backend. Check backend.copy()"
-        backend.runpf(is_dc=False)
+        res = backend.runpf(is_dc=False)
+        assert res[0],  f"Your backend diverged in AC after a copy, error was {res[1]}"    
         # now modify original one
         init_gen_p, *_ = backend.generators_info() 
         init_load_p, *_ = backend.loads_info()
@@ -1274,6 +1289,7 @@ class AAATestBackendAPI(MakeBackend):
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=True) 
         res_cpy = backend_cpy.runpf(is_dc=True) 
+        assert res_cpy[0],  f"Your backend diverged in DC after a copy, error was {res_cpy[1]}"    
         
         p_or, *_ = backend.lines_or_info()
         p_or_cpy, *_ = backend_cpy.lines_or_info()
@@ -1302,6 +1318,7 @@ class AAATestBackendAPI(MakeBackend):
         cls = type(backend)
         
         res = backend.runpf(is_dc=False)
+        assert res[0],  f"Your backend diverged in AC after loading, error was {res[1]}"    
         topo_vect_orig = self._aux_check_topo_vect(backend)
         
         # disconnect line
@@ -1313,6 +1330,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=False)  
+        assert res[0],  f"Your backend diverged in AC after a line disconnection, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
         error_msg = (f"Line {line_id} has been disconnected, yet according to 'topo_vect' "
                      f"is still connected (origin side) to busbar {topo_vect[cls.line_or_pos_topo_vect[line_id]]}")
@@ -1331,6 +1349,7 @@ class AAATestBackendAPI(MakeBackend):
             bk_act += action
             backend.apply_action(bk_act)
             res = backend.runpf(is_dc=False)  
+            assert res[0],  f"Your backend diverged in AC after a storage disconnection, error was {res[1]}"    
             topo_vect = self._aux_check_topo_vect(backend)
             error_msg = (f"Storage {sto_id} has been disconnected, yet according to 'topo_vect' "
                         f"is still connected (origin side) to busbar {topo_vect[cls.storage_pos_topo_vect[line_id]]}")
@@ -1353,6 +1372,7 @@ class AAATestBackendAPI(MakeBackend):
             bk_act += action
             backend.apply_action(bk_act)
             res = backend.runpf(is_dc=False)  
+            assert res[0],  f"Your backend diverged in AC after a shunt disconnection, error was {res[1]}"    
             topo_vect = self._aux_check_topo_vect(backend)
             error_msg = (f"Disconnecting a shunt should have no impact on the topo_vect vector "
                          f"as shunt are not taken into account in this")
@@ -1439,6 +1459,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)  # apply the action
         res = backend.runpf(is_dc=False)  
+        assert res[0],  f"Your backend diverged in AC after setting a {el_nm} on busbar {busbar_id}, error was {res[1]}"    
         # now check the topology vector
         topo_vect = self._aux_check_topo_vect(backend)
         error_msg = (f"{el_nm} {el_id} has been moved to busbar {busbar_id}, yet according to 'topo_vect' "
@@ -1464,6 +1485,7 @@ class AAATestBackendAPI(MakeBackend):
         cls = type(backend)
         
         res = backend.runpf(is_dc=False)
+        assert res[0],  f"Your backend diverged in AC after loading the grid state, error was {res[1]}"    
         topo_vect_orig = self._aux_check_topo_vect(backend)
         
         # line or
@@ -1476,6 +1498,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=False)  
+        assert res[0],  f"Your backend diverged in AC after setting a line (or side) on busbar 2, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
         error_msg = (f"Line {line_id} (or. side) has been moved to busbar {busbar_id}, yet according to 'topo_vect' "
                      f"is still connected (origin side) to busbar {topo_vect[cls.line_or_pos_topo_vect[line_id]]}")
@@ -1491,6 +1514,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act += action
         backend.apply_action(bk_act)
         res = backend.runpf(is_dc=False)  
+        assert res[0],  f"Your backend diverged in AC after setting a line (ex side) on busbar 2, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
         error_msg = (f"Line {line_id} (ex. side) has been moved to busbar {busbar_id}, yet according to 'topo_vect' "
                      f"is still connected (ext side) to busbar {topo_vect[cls.line_ex_pos_topo_vect[line_id]]}")

--- a/grid2op/tests/helper_path_test.py
+++ b/grid2op/tests/helper_path_test.py
@@ -10,6 +10,7 @@
 # root package directory
 # Grid2Op subdirectory
 # Grid2Op/tests subdirectory
+
 import sys
 import os
 import numpy as np
@@ -24,7 +25,10 @@ grid2op_dir = os.fspath(test_dir.parent.absolute())
 data_test_dir = os.path.abspath(os.path.join(grid2op_dir, "data_test"))
 data_dir = os.path.abspath(os.path.join(grid2op_dir, "data"))
 
-sys.path.insert(0, grid2op_dir)
+# sys.path.insert(0, grid2op_dir)  # cause https://github.com/rte-france/Grid2Op/issues/577
+# because the addition of `from grid2op._create_test_suite import create_test_suite`
+# in grid2op "__init__.py"
+
 
 PATH_DATA = data_dir
 PATH_DATA_TEST = data_test_dir

--- a/grid2op/tests/helper_path_test.py
+++ b/grid2op/tests/helper_path_test.py
@@ -63,6 +63,13 @@ class MakeBackend(ABC, HelperTests):
     def make_backend(self, detailed_infos_for_cascading_failures=False) -> Backend:
         pass
 
+    def make_backend_with_glue_code(self, detailed_infos_for_cascading_failures=False, extra_name="") -> Backend:
+        Backend._clear_class_attribute()
+        bk = self.make_backend(detailed_infos_for_cascading_failures=detailed_infos_for_cascading_failures)
+        type(bk)._clear_grid_dependant_class_attributes()
+        type(bk).set_env_name(type(self).__name__ + extra_name)
+        return bk
+    
     def get_path(self) -> str:
         raise NotImplementedError(
             "This function should be implemented for the test suit you are developping"

--- a/grid2op/tests/test_Environment.py
+++ b/grid2op/tests/test_Environment.py
@@ -845,7 +845,7 @@ class TestDeactivateForecast(unittest.TestCase):
         # type of power flow to play
         # if True, then it will not disconnect lines above their thermal limits
         assert env._no_overflow_disconnection == param.NO_OVERFLOW_DISCONNECTION
-        assert env._hard_overflow_threshold == param.HARD_OVERFLOW_THRESHOLD
+        assert (env._hard_overflow_threshold == param.HARD_OVERFLOW_THRESHOLD).all()
 
         # store actions "cooldown"
         assert (

--- a/grid2op/tests/test_MaskedEnvironment.py
+++ b/grid2op/tests/test_MaskedEnvironment.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2019-2023, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import warnings
+import unittest
+import numpy as np
+
+import grid2op
+from grid2op.Environment import MaskedEnvironment
+from grid2op.Runner import Runner
+from grid2op.gym_compat import (GymEnv,
+                                BoxGymActSpace,
+                                BoxGymObsSpace,
+                                DiscreteActSpace,
+                                MultiDiscreteActSpace)
+            
+            
+class TestMaskedEnvironment(unittest.TestCase):        
+    def get_mask(self):
+        mask = np.full(20, fill_value=False, dtype=bool)
+        mask[[0, 1, 4, 2, 3, 6, 5]] = True  # THT part
+        return mask
+    
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env_in = MaskedEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
+                                            lines_of_interest=self.get_mask())
+            self.env_out = MaskedEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
+                                            lines_of_interest=~self.get_mask())
+        self.line_id = 3
+        th_lim = self.env_in.get_thermal_limit() * 2.  # avoid all problem in general
+        th_lim[self.line_id] /= 10.  # make sure to get trouble in line 3
+        # env_in: line is int the area
+        self.env_in.set_thermal_limit(th_lim)
+        # env_out: line is out of the area
+        self.env_out.set_thermal_limit(th_lim)
+        
+        self._init_env(self.env_in)
+        self._init_env(self.env_out)
+    
+    def _init_env(self, env):
+        env.set_id(0)
+        env.seed(0)
+        env.reset()
+        
+    def tearDown(self) -> None:
+        self.env_in.close()
+        self.env_out.close()
+        return super().tearDown()
+    
+    def test_right_type(self):
+        assert isinstance(self.env_in, MaskedEnvironment)
+        assert isinstance(self.env_out, MaskedEnvironment)
+        assert hasattr(self.env_in, "_lines_of_interest")
+        assert hasattr(self.env_out, "_lines_of_interest")
+        assert self.env_in._lines_of_interest[self.line_id], "line_id should be in env_in"
+        assert not self.env_out._lines_of_interest[self.line_id], "line_id should not be in env_out"
+    
+    def test_ok(self):
+        act = self.env_in.action_space()
+        for i in range(10):
+            obs_in, reward, done, info = self.env_in.step(act)
+            obs_out, reward, done, info = self.env_out.step(act)
+            if i < 2:  # 2 : 2 full steps already
+                assert obs_in.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
+                assert obs_out.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
+            else:
+                # cooldown applied for line 3: 
+                # - it disconnect stuff in `self.env_in`
+                # - it does not affect anything in `self.env_out`
+                assert not obs_in.line_status[self.line_id]
+                assert obs_out.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
+    
+    def test_reset(self):
+        # timestep_overflow should be 0 initially even if the flow is too high
+        obs = self.env_in.reset()
+        assert obs.timestep_overflow[self.line_id] == 0
+        assert obs.rho[self.line_id] > 1.
+        
+
+class TestTimedOutEnvironmentCpy(TestMaskedEnvironment):
+    def setUp(self) -> None:
+        super().setUp()
+        init_int = self.env_in.copy()
+        init_out = self.env_out.copy()
+        self.env0 = self.env_in.copy()
+        self.env1 = self.env_out.copy()
+        init_int.close()
+        init_out.close()
+        
+
+# class TestTOEnvRunner(unittest.TestCase):
+#     def get_timeout_ms(self):
+#         return 200
+    
+#     def setUp(self) -> None:
+#         with warnings.catch_warnings():
+#             warnings.filterwarnings("ignore")
+#             self.env1 = TimedOutEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
+#                                             time_out_ms=self.get_timeout_ms())
+#         params = self.env1.parameters
+#         params.NO_OVERFLOW_DISCONNECTION = True
+#         self.env1.change_parameters(params)
+#         self.cum_reward = 645.70208
+#         self.max_iter = 10
+
+#     def tearDown(self) -> None:
+#         self.env1.close()
+#         return super().tearDown()
+        
+#     def test_runner_can_make(self):
+#         runner = Runner(**self.env1.get_params_for_runner())
+#         env2 = runner.init_env()
+#         assert isinstance(env2, TimedOutEnvironment)
+#         assert env2.time_out_ms == self.get_timeout_ms()
+    
+#     def test_runner_noskip(self):
+#         agent = AgentOK(self.env1)
+#         runner = Runner(**self.env1.get_params_for_runner(),
+#                         agentClass=None,
+#                         agentInstance=agent)
+#         res = runner.run(nb_episode=1,
+#                          max_iter=self.max_iter)
+#         _, _, cum_reward, timestep, max_ts = res[0]
+#         assert abs(cum_reward - self.cum_reward) <= 1e-5
+    
+#     def test_runner_skip1(self):
+#         agent = AgentKO(self.env1)
+#         runner = Runner(**self.env1.get_params_for_runner(),
+#                         agentClass=None,
+#                         agentInstance=agent)
+#         res = runner.run(nb_episode=1,
+#                          max_iter=self.max_iter)
+#         _, _, cum_reward, timestep, max_ts = res[0]
+#         assert abs(cum_reward - self.cum_reward) <= 1e-5
+    
+#     def test_runner_skip2(self):
+#         agent = AgentKO2(self.env1)
+#         runner = Runner(**self.env1.get_params_for_runner(),
+#                         agentClass=None,
+#                         agentInstance=agent)
+#         res = runner.run(nb_episode=1,
+#                          max_iter=self.max_iter)
+#         _, _, cum_reward, timestep, max_ts = res[0]
+#         assert abs(cum_reward - self.cum_reward) <= 1e-5
+    
+#     def test_runner_skip2_2ep(self):
+#         agent = AgentKO2(self.env1)
+#         runner = Runner(**self.env1.get_params_for_runner(),
+#                         agentClass=None,
+#                         agentInstance=agent)
+#         res = runner.run(nb_episode=2,
+#                          max_iter=self.max_iter)
+#         _, _, cum_reward, timestep, max_ts = res[0]
+#         assert abs(cum_reward - self.cum_reward) <= 1e-5
+#         _, _, cum_reward, timestep, max_ts = res[1]
+#         assert abs(cum_reward - 648.90795) <= 1e-5
+    
+
+# class TestTOEnvGym(unittest.TestCase):
+#     def get_timeout_ms(self):
+#         return 400.
+    
+#     def setUp(self) -> None:
+#         with warnings.catch_warnings():
+#             warnings.filterwarnings("ignore")
+#             self.env1 = TimedOutEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
+#                                             time_out_ms=self.get_timeout_ms())
+
+#     def tearDown(self) -> None:
+#         self.env1.close()
+#         return super().tearDown()
+    
+#     def test_gym_with_step(self):
+#         """test the step function also makes the 'do nothing'"""
+#         self.skipTest("On docker execution time is too unstable")
+#         env_gym = GymEnv(self.env1)
+#         env_gym.reset()
+        
+#         agentok = AgentOK(env_gym)
+#         for i in range(10):
+#             act = agentok.act_gym(None, None, None)
+#             for k in act:
+#                 act[k][:] = 0
+#             *_, info = env_gym.step(act)
+#             assert info["nb_do_nothing"] == 0
+#             assert info["nb_do_nothing_made"] == 0
+#             assert env_gym.init_env._nb_dn_last == 0
+            
+#         env_gym.reset()
+#         agentko = AgentKO1(env_gym)
+#         for i in range(10):
+#             act = agentko.act_gym(None, None, None)
+#             for k in act:
+#                 act[k][:] = 0
+#             *_, info = env_gym.step(act)
+#             assert info["nb_do_nothing"] == 1
+#             assert info["nb_do_nothing_made"] == 1
+#             assert env_gym.init_env._nb_dn_last == 1
+            
+#     def test_gym_normal(self):
+#         """test I can create the gym env"""
+#         env_gym = GymEnv(self.env1)
+#         env_gym.reset()
+    
+#     def test_gym_box(self):
+#         """test I can create the gym env with box ob space and act space"""
+#         env_gym = GymEnv(self.env1)
+#         with warnings.catch_warnings():
+#             warnings.filterwarnings("ignore")
+#             env_gym.action_space = BoxGymActSpace(self.env1.action_space)
+#             env_gym.observation_space = BoxGymObsSpace(self.env1.observation_space)
+#         env_gym.reset()
+    
+#     def test_gym_discrete(self):
+#         """test I can create the gym env with discrete act space"""
+#         env_gym = GymEnv(self.env1)
+#         with warnings.catch_warnings():
+#             warnings.filterwarnings("ignore")
+#             env_gym.action_space = DiscreteActSpace(self.env1.action_space)
+#         env_gym.reset()
+    
+#     def test_gym_multidiscrete(self):
+#         """test I can create the gym env with multi discrete act space"""
+#         env_gym = GymEnv(self.env1)
+#         with warnings.catch_warnings():
+#             warnings.filterwarnings("ignore")
+#             env_gym.action_space = MultiDiscreteActSpace(self.env1.action_space)
+#         env_gym.reset()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grid2op/tests/test_MaskedEnvironment.py
+++ b/grid2op/tests/test_MaskedEnvironment.py
@@ -20,8 +20,9 @@ from grid2op.gym_compat import (GymEnv,
                                 MultiDiscreteActSpace)
             
             
-class TestMaskedEnvironment(unittest.TestCase):        
-    def get_mask(self):
+class TestMaskedEnvironment(unittest.TestCase):      
+    @staticmethod  
+    def get_mask():
         mask = np.full(20, fill_value=False, dtype=bool)
         mask[[0, 1, 4, 2, 3, 6, 5]] = True  # THT part
         return mask
@@ -30,9 +31,9 @@ class TestMaskedEnvironment(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env_in = MaskedEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
-                                            lines_of_interest=self.get_mask())
+                                            lines_of_interest=TestMaskedEnvironment.get_mask())
             self.env_out = MaskedEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
-                                            lines_of_interest=~self.get_mask())
+                                            lines_of_interest=~TestMaskedEnvironment.get_mask())
         self.line_id = 3
         th_lim = self.env_in.get_thermal_limit() * 2.  # avoid all problem in general
         th_lim[self.line_id] /= 10.  # make sure to get trouble in line 3
@@ -41,10 +42,11 @@ class TestMaskedEnvironment(unittest.TestCase):
         # env_out: line is out of the area
         self.env_out.set_thermal_limit(th_lim)
         
-        self._init_env(self.env_in)
-        self._init_env(self.env_out)
-    
-    def _init_env(self, env):
+        TestMaskedEnvironment._init_env(self.env_in)
+        TestMaskedEnvironment._init_env(self.env_out)
+        
+    @staticmethod  
+    def _init_env(env):
         env.set_id(0)
         env.seed(0)
         env.reset()
@@ -69,13 +71,13 @@ class TestMaskedEnvironment(unittest.TestCase):
             obs_out, reward, done, info = self.env_out.step(act)
             if i < 2:  # 2 : 2 full steps already
                 assert obs_in.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
-                assert obs_out.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
+                assert obs_out.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_out.timestep_overflow[self.line_id]}"
             else:
                 # cooldown applied for line 3: 
                 # - it disconnect stuff in `self.env_in`
                 # - it does not affect anything in `self.env_out`
                 assert not obs_in.line_status[self.line_id]
-                assert obs_out.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
+                assert obs_out.timestep_overflow[self.line_id] == i + 1, f"error for step {i}: {obs_out.timestep_overflow[self.line_id]}"
     
     def test_reset(self):
         # timestep_overflow should be 0 initially even if the flow is too high
@@ -84,155 +86,144 @@ class TestMaskedEnvironment(unittest.TestCase):
         assert obs.rho[self.line_id] > 1.
         
 
-class TestTimedOutEnvironmentCpy(TestMaskedEnvironment):
+class TestMaskedEnvironmentCpy(TestMaskedEnvironment):
     def setUp(self) -> None:
         super().setUp()
-        init_int = self.env_in.copy()
-        init_out = self.env_out.copy()
-        self.env0 = self.env_in.copy()
-        self.env1 = self.env_out.copy()
+        init_int = self.env_in
+        init_out = self.env_out
+        self.env_in = self.env_in.copy()
+        self.env_out = self.env_out.copy()
         init_int.close()
         init_out.close()
         
 
-# class TestTOEnvRunner(unittest.TestCase):
-#     def get_timeout_ms(self):
-#         return 200
-    
-#     def setUp(self) -> None:
-#         with warnings.catch_warnings():
-#             warnings.filterwarnings("ignore")
-#             self.env1 = TimedOutEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
-#                                             time_out_ms=self.get_timeout_ms())
-#         params = self.env1.parameters
-#         params.NO_OVERFLOW_DISCONNECTION = True
-#         self.env1.change_parameters(params)
-#         self.cum_reward = 645.70208
-#         self.max_iter = 10
+class TestMaskedEnvironmentRunner(unittest.TestCase):    
+    def setUp(self) -> None:
+        TestMaskedEnvironment.setUp(self)
+        self.max_iter = 10
 
-#     def tearDown(self) -> None:
-#         self.env1.close()
-#         return super().tearDown()
+    def tearDown(self) -> None:
+        self.env_in.close()
+        self.env_out.close()
+        return super().tearDown()
         
-#     def test_runner_can_make(self):
-#         runner = Runner(**self.env1.get_params_for_runner())
-#         env2 = runner.init_env()
-#         assert isinstance(env2, TimedOutEnvironment)
-#         assert env2.time_out_ms == self.get_timeout_ms()
+    def test_runner_can_make(self):
+        runner = Runner(**self.env_in.get_params_for_runner())
+        env2 = runner.init_env()
+        assert isinstance(env2, MaskedEnvironment)
+        assert (env2._lines_of_interest == self.env_in._lines_of_interest).all()
     
-#     def test_runner_noskip(self):
-#         agent = AgentOK(self.env1)
-#         runner = Runner(**self.env1.get_params_for_runner(),
-#                         agentClass=None,
-#                         agentInstance=agent)
-#         res = runner.run(nb_episode=1,
-#                          max_iter=self.max_iter)
-#         _, _, cum_reward, timestep, max_ts = res[0]
-#         assert abs(cum_reward - self.cum_reward) <= 1e-5
-    
-#     def test_runner_skip1(self):
-#         agent = AgentKO(self.env1)
-#         runner = Runner(**self.env1.get_params_for_runner(),
-#                         agentClass=None,
-#                         agentInstance=agent)
-#         res = runner.run(nb_episode=1,
-#                          max_iter=self.max_iter)
-#         _, _, cum_reward, timestep, max_ts = res[0]
-#         assert abs(cum_reward - self.cum_reward) <= 1e-5
-    
-#     def test_runner_skip2(self):
-#         agent = AgentKO2(self.env1)
-#         runner = Runner(**self.env1.get_params_for_runner(),
-#                         agentClass=None,
-#                         agentInstance=agent)
-#         res = runner.run(nb_episode=1,
-#                          max_iter=self.max_iter)
-#         _, _, cum_reward, timestep, max_ts = res[0]
-#         assert abs(cum_reward - self.cum_reward) <= 1e-5
-    
-#     def test_runner_skip2_2ep(self):
-#         agent = AgentKO2(self.env1)
-#         runner = Runner(**self.env1.get_params_for_runner(),
-#                         agentClass=None,
-#                         agentInstance=agent)
-#         res = runner.run(nb_episode=2,
-#                          max_iter=self.max_iter)
-#         _, _, cum_reward, timestep, max_ts = res[0]
-#         assert abs(cum_reward - self.cum_reward) <= 1e-5
-#         _, _, cum_reward, timestep, max_ts = res[1]
-#         assert abs(cum_reward - 648.90795) <= 1e-5
-    
-
-# class TestTOEnvGym(unittest.TestCase):
-#     def get_timeout_ms(self):
-#         return 400.
-    
-#     def setUp(self) -> None:
-#         with warnings.catch_warnings():
-#             warnings.filterwarnings("ignore")
-#             self.env1 = TimedOutEnvironment(grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__),
-#                                             time_out_ms=self.get_timeout_ms())
-
-#     def tearDown(self) -> None:
-#         self.env1.close()
-#         return super().tearDown()
-    
-#     def test_gym_with_step(self):
-#         """test the step function also makes the 'do nothing'"""
-#         self.skipTest("On docker execution time is too unstable")
-#         env_gym = GymEnv(self.env1)
-#         env_gym.reset()
+    def test_runner(self):
+        # create the runner
+        runner_in = Runner(**self.env_in.get_params_for_runner())
+        runner_out = Runner(**self.env_out.get_params_for_runner())
+        res_in, *_ = runner_in.run(nb_episode=1, max_iter=self.max_iter, env_seeds=[0], episode_id=[0], add_detailed_output=True)
+        res_out, *_ = runner_out.run(nb_episode=1, max_iter=self.max_iter, env_seeds=[0], episode_id=[0], add_detailed_output=True)
+        res_in2, *_ = runner_in.run(nb_episode=1, max_iter=self.max_iter, env_seeds=[0], episode_id=[0])
+        # check correct results are obtained when agregated
+        assert res_in[3] == 10
+        assert res_in2[3] == 10
+        assert res_out[3] == 10
+        assert np.allclose(res_in[2], 645.4992065)
+        assert np.allclose(res_in2[2], 645.4992065)
+        assert np.allclose(res_out[2], 645.7020874)
         
-#         agentok = AgentOK(env_gym)
-#         for i in range(10):
-#             act = agentok.act_gym(None, None, None)
-#             for k in act:
-#                 act[k][:] = 0
-#             *_, info = env_gym.step(act)
-#             assert info["nb_do_nothing"] == 0
-#             assert info["nb_do_nothing_made"] == 0
-#             assert env_gym.init_env._nb_dn_last == 0
+        # check detailed results
+        ep_data_in = res_in[-1]
+        ep_data_out = res_out[-1]
+        for i in range(self.max_iter + 1):
+            obs_in = ep_data_in.observations[i]
+            obs_out = ep_data_out.observations[i]
+            if i < 3:
+                assert obs_in.timestep_overflow[self.line_id] == i, f"error for step {i}: {obs_in.timestep_overflow[self.line_id]}"
+                assert obs_out.timestep_overflow[self.line_id] == i, f"error for step {i}: {obs_out.timestep_overflow[self.line_id]}"
+            else:
+                # cooldown applied for line 3: 
+                # - it disconnect stuff in `self.env_in`
+                # - it does not affect anything in `self.env_out`
+                assert not obs_in.line_status[self.line_id], f"error for step {i}: line is not disconnected"
+                assert obs_out.timestep_overflow[self.line_id] == i, f"error for step {i}: {obs_out.timestep_overflow[self.line_id]}"
+    
+        
+        
+class TestMaskedEnvironmentGym(unittest.TestCase):
+    def setUp(self) -> None:
+        TestMaskedEnvironment.setUp(self)
+
+    def tearDown(self) -> None:
+        self.env_in.close()
+        self.env_out.close()
+        return super().tearDown()
+    
+    def _aux_run_envs(self, act, env_gym_in, env_gym_out):
+        for i in range(10):
+            obs_in, reward, done, truncated, info = env_gym_in.step(act)
+            obs_out, reward, done, truncated, info = env_gym_out.step(act)
+            if i < 2:  # 2 : 2 full steps already
+                assert obs_in["timestep_overflow"][self.line_id] == i + 1, f"error for step {i}: {obs_in['timestep_overflow'][self.line_id]}"
+                assert obs_out['timestep_overflow'][self.line_id] == i + 1, f"error for step {i}: {obs_out['timestep_overflow'][self.line_id]}"
+            else:
+                # cooldown applied for line 3: 
+                # - it disconnect stuff in `self.env_in`
+                # - it does not affect anything in `self.env_out`
+                assert not obs_in["line_status"][self.line_id]
+                assert obs_out["timestep_overflow"][self.line_id] == i + 1, f"error for step {i}: {obs_out['timestep_overflow'][self.line_id]}"
+    
+    def test_gym_with_step(self):
+        """test the step function also disconnects (or not) the lines"""
+        env_gym_in = GymEnv(self.env_in)
+        env_gym_out = GymEnv(self.env_out)
+        act = {}
+        self._aux_run_envs(act, env_gym_in, env_gym_out)
+        env_gym_in.reset()
+        env_gym_out.reset()
+        self._aux_run_envs(act, env_gym_in, env_gym_out)
             
-#         env_gym.reset()
-#         agentko = AgentKO1(env_gym)
-#         for i in range(10):
-#             act = agentko.act_gym(None, None, None)
-#             for k in act:
-#                 act[k][:] = 0
-#             *_, info = env_gym.step(act)
-#             assert info["nb_do_nothing"] == 1
-#             assert info["nb_do_nothing_made"] == 1
-#             assert env_gym.init_env._nb_dn_last == 1
-            
-#     def test_gym_normal(self):
-#         """test I can create the gym env"""
-#         env_gym = GymEnv(self.env1)
-#         env_gym.reset()
+    def test_gym_normal(self):
+        """test I can create the gym env"""
+        env_gym = GymEnv(self.env_in)
+        env_gym.reset()
     
-#     def test_gym_box(self):
-#         """test I can create the gym env with box ob space and act space"""
-#         env_gym = GymEnv(self.env1)
-#         with warnings.catch_warnings():
-#             warnings.filterwarnings("ignore")
-#             env_gym.action_space = BoxGymActSpace(self.env1.action_space)
-#             env_gym.observation_space = BoxGymObsSpace(self.env1.observation_space)
-#         env_gym.reset()
+    def test_gym_box(self):
+        """test I can create the gym env with box ob space and act space"""
+        env_gym_in = GymEnv(self.env_in)
+        env_gym_out = GymEnv(self.env_out)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env_gym_in.action_space = BoxGymActSpace(self.env_in.action_space)
+            env_gym_in.observation_space = BoxGymObsSpace(self.env_in.observation_space)
+            env_gym_out.action_space = BoxGymActSpace(self.env_out.action_space)
+            env_gym_out.observation_space = BoxGymObsSpace(self.env_out.observation_space)
+        env_gym_in.reset()
+        env_gym_out.reset()
     
-#     def test_gym_discrete(self):
-#         """test I can create the gym env with discrete act space"""
-#         env_gym = GymEnv(self.env1)
-#         with warnings.catch_warnings():
-#             warnings.filterwarnings("ignore")
-#             env_gym.action_space = DiscreteActSpace(self.env1.action_space)
-#         env_gym.reset()
+    def test_gym_discrete(self):
+        """test I can create the gym env with discrete act space"""
+        env_gym_in = GymEnv(self.env_in)
+        env_gym_out = GymEnv(self.env_out)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env_gym_in.action_space = DiscreteActSpace(self.env_in.action_space)
+            env_gym_out.action_space = DiscreteActSpace(self.env_out.action_space)
+        env_gym_in.reset()
+        env_gym_out.reset()
+        act = 0
+        self._aux_run_envs(act, env_gym_in, env_gym_out)
+        
     
-#     def test_gym_multidiscrete(self):
-#         """test I can create the gym env with multi discrete act space"""
-#         env_gym = GymEnv(self.env1)
-#         with warnings.catch_warnings():
-#             warnings.filterwarnings("ignore")
-#             env_gym.action_space = MultiDiscreteActSpace(self.env1.action_space)
-#         env_gym.reset()
+    def test_gym_multidiscrete(self):
+        """test I can create the gym env with multi discrete act space"""
+        env_gym_in = GymEnv(self.env_in)
+        env_gym_out = GymEnv(self.env_out)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env_gym_in.action_space = MultiDiscreteActSpace(self.env_in.action_space)
+            env_gym_out.action_space = MultiDiscreteActSpace(self.env_out.action_space)
+        env_gym_in.reset()
+        env_gym_out.reset()
+        act = env_gym_in.action_space.sample()
+        act[:] = 0
+        self._aux_run_envs(act, env_gym_in, env_gym_out)
 
 
 if __name__ == "__main__":

--- a/grid2op/tests/test_Runner.py
+++ b/grid2op/tests/test_Runner.py
@@ -505,6 +505,8 @@ class TestRunner(HelperTests, unittest.TestCase):
             "1.9.3",
             "1.9.4",
             "1.9.5",
+            "1.9.6",
+            "1.9.7",
         ]
         curr_version = "test_version"
         assert (

--- a/grid2op/tests/test_new_reset.py
+++ b/grid2op/tests/test_new_reset.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+import grid2op
+import unittest
+import warnings
+import numpy as np
+from grid2op.Exceptions import EnvError
+from grid2op.gym_compat import GymEnv
+
+
+class TestNewReset(unittest.TestCase):
+    """
+    This class tests the possibility to set the seed and the time
+    serie id directly when calling `env.reset`
+    """
+
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__)
+    
+    def test_normal_env(self):
+        # original way
+        self.env.set_id(0)
+        self.env.seed(0)
+        obs = self.env.reset()
+        
+        # test with seed in reset
+        self.env.set_id(0)
+        obs_seed = self.env.reset(seed=0)
+        
+        # test with ts_id in reset
+        self.env.seed(0)
+        obs_ts = self.env.reset(options={"time serie id": 0})
+        
+        # test with both
+        obs_both = self.env.reset(seed=0, options={"time serie id": 0})
+        assert obs_seed == obs
+        assert obs_ts == obs
+        assert obs_both == obs
+    
+    def test_raise_if_wrong_key(self):
+        with self.assertRaises(EnvError):
+            obs_ts = self.env.reset(options={"time series id": 0})
+            
+        with self.assertRaises(EnvError):
+            obs_ts = self.env.reset(options={"chronics id": 0})
+    
+    def _aux_obs_equals(self, obs1, obs2):
+        assert obs1.keys() == obs2.keys(), f"not the same keys"
+        for el in obs1:
+            assert np.array_equal(obs1[el], obs2[el]), f"obs not equal for attribute {el}"
+            
+    def test_gym_env(self):
+        gym_env = GymEnv(self.env)
+        
+        # original way
+        gym_env.init_env.set_id(0)
+        gym_env.init_env.seed(0)
+        obs, *_ = gym_env.reset()
+        
+        # test with seed in reset
+        gym_env.init_env.set_id(0)
+        obs_seed, *_ = gym_env.reset(seed=0)
+        
+        # test with ts_id in reset
+        gym_env.init_env.seed(0)
+        obs_ts, *_ = gym_env.reset(options={"time serie id": 0})
+        
+        # test with both
+        obs_both, *_ = gym_env.reset(seed=0, options={"time serie id": 0})
+
+        self._aux_obs_equals(obs_seed, obs)
+        self._aux_obs_equals(obs_ts, obs)
+        self._aux_obs_equals(obs_both, obs)
+        

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,11 @@ if sys.version_info.minor <= 7:
     
 if sys.version_info.minor == 12:
     # numba is not available for python 3.12 at the moment
-    pkgs["extras"]["test"] = [el for el in  pkgs["extras"]["test"] if not ("numba" in el)]
+    pkgs["extras"]["test"] = [el for el in  pkgs["extras"]["test"] if (not ("numba" in el) and 
+                                                                       not ("gym" in el) and 
+                                                                       not ('stable-baselines3' in el)
+                                                                       )
+                              ]
 
 setup(description='An gymnasium compatible environment to model sequential decision making  for powersystems',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ pkgs = {
                  "numba",
                  "gym>=0.26",
                  "gymnasium",
-                 "stable-baselines3>=2.0",
+                #  "stable-baselines3>=2.0",
                  "nbconvert",
                  "jinja2"
                  ],


### PR DESCRIPTION
- [FIXED] the `backend.check_kirchoff` function was not correct when some elements were disconnected 
  (the wrong columns of the p_bus and q_bus was set in case of disconnected elements)
- [FIXED] `PandapowerBackend`, when no slack was present
- [FIXED] the "BaseBackendTest" class did not correctly detect divergence in most cases (which lead 
  to weird bugs in failing tests)
- [FIXED] an issue with imageio having deprecated the `fps` kwargs (see https://github.com/rte-france/Grid2Op/issues/569)
- [FIXED] adding the "`loads_charac.csv`" in the package data
- [FIXED] a bug when using grid2op, not "utils.py" script could be used (see 
  https://github.com/rte-france/Grid2Op/issues/577). This was caused by the modification of
  `sys.path` when importing the grid2op test suite.
- [ADDED] A type of environment that does not perform the "emulation of the protections"
  for some part of the grid (`MaskedEnvironment`) see https://github.com/rte-france/Grid2Op/issues/571
- [ADDED] a "gym like" API for reset allowing to set the seed and the time serie id directly when calling
  `env.reset(seed=.., options={"time serie id": ...})`
- [IMPROVED] the CI speed: by not testing every possible numpy version but only most ancient and most recent
- [IMPROVED] Runner now test grid2op version 1.9.6 and 1.9.7
- [IMPROVED] refacto `gridobj_cls._clear_class_attribute` and `gridobj_cls._clear_grid_dependant_class_attributes`
- [IMPROVED] the bahviour of the generic class `MakeBackend` used for the test suite.
- [IMPROVED] re introducing python 12 testing
- [IMPROVED] error messages in the automatic test suite (`AAATestBackendAPI`)