### PR TITLE
Debug: Fix Missing Legal and Ambigious Arrays in CompactEpisodeData

### DIFF
--- a/grid2op/Episode/CompactEpisodeData.py
+++ b/grid2op/Episode/CompactEpisodeData.py
@@ -95,9 +95,11 @@ class CompactEpisodeData():
         """
         if exp_dir is not None:
             self.exp_dir = p(exp_dir)
+            self.exp_dir = self.exp_dir / "CompactEpisodeData"
+            self.exp_dir.mkdir(parents=False, exist_ok=True)
         else:
             self.exp_dir = None
-        self.array_names = ("actions", "env_actions", "attacks", "observations", "rewards", "other_rewards", "disc_lines", "times")
+        self.array_names = ("actions", "env_actions", "attacks", "observations", "rewards", "other_rewards", "disc_lines", "times", "legal", "ambiguous")
         self.space_names = ("observation_space", "action_space", "attack_space", "env_modification_space")
         if ep_id is None:
             self.ep_id = env.chronics_handler.get_name()

--- a/grid2op/Runner/runner.py
+++ b/grid2op/Runner/runner.py
@@ -1728,7 +1728,7 @@ class Runner(object):
                     )
                 else:
                     if add_detailed_output and (_IS_WINDOWS or _IS_MACOS):
-                        self.logger.warn(
+                        self.logger.warning(
                             "Parallel run are not fully supported on windows or macos when "
                             '"add_detailed_output" is True. So we decided '
                             "to fully deactivate them."

--- a/grid2op/tests/test_CompactEpisodeData.py
+++ b/grid2op/tests/test_CompactEpisodeData.py
@@ -181,10 +181,8 @@ class TestCompactEpisodeData(unittest.TestCase):
             agentClass=OneChange,
             use_compact_episode_data=True,
         )
-        with warnings.catch_warnings(category=UserWarning, action="ignore"):
-            *_, episode_data = runner.run_one_episode(
-                max_iter=self.max_iter, detailed_output=True,
-            )
+        *_, episode_data = runner.run_one_episode(
+            max_iter=self.max_iter, detailed_output=True,
         # Check that the type of first action is set bus
         assert episode_data.action_space.from_vect(episode_data.actions[0]).get_types()[2]
 

--- a/grid2op/tests/test_CompactEpisodeData.py
+++ b/grid2op/tests/test_CompactEpisodeData.py
@@ -181,8 +181,11 @@ class TestCompactEpisodeData(unittest.TestCase):
             agentClass=OneChange,
             use_compact_episode_data=True,
         )
-        *_, episode_data = runner.run_one_episode(
-            max_iter=self.max_iter, detailed_output=True,
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            *_, episode_data = runner.run_one_episode(
+                max_iter=self.max_iter, detailed_output=True,
+            )
         # Check that the type of first action is set bus
         assert episode_data.action_space.from_vect(episode_data.actions[0]).get_types()[2]
 


### PR DESCRIPTION
Update to CompactEpisodeData to ensure legal and ambigious actions are also captured, previously they were not being saved to file alongside the other arrays.

**Note**: The replacement for the deprecated OneChangeThenNothing class is; 'self.action_space(cls.my_dict).to_json()' however this does not work as a good replacement in the `test_CompactEpisodeData.test_collection_wrapper_after_run` unit test since the action space is not accessible from a runner instance. Hence I have ignored the warning of this for now.



