### PR TITLE
Some fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -103,13 +103,21 @@ Native multi agents support:
 
 [1.12.4] - 2026-xx-yy
 ----------------------
+- [BREAKING] the behaviour of grid2op environment when ENV_DOES_REDISPATCHING
+  flag is turned on is changed and is now exactly the one 
+  described in the doc (before it completly skipped the redispathcing / curtailment 
+  storage)
 - [FIXED] copy on write issues in PandaPowerBackend
 - [FIXED] a bug causing https://github.com/Grid2op/lightsim2grid/issues/128
 - [FIXED] some warnings in the docstrings (escaped character)
 - [FIXED] some issues spotted by sonarcloud (especially attribute names)
+- [FIXED] doc about the ENV_DOES_REDISPATCHING parameters. see issue 
+  https://github.com/grid2op/grid2op/issues/752 
 - [IMPROVED] security in the way episode statistics are saved (to prevent malicious 
   tempering with path)
 - [IMPROVED] use df.to_numpy() instead of df.values when df is a pandas dataframe
+- [IMPROVED] grid2op parameters now uses "slots" to avoid setting incorrect values
+  not used by grid2op.
 - [ADDED] some tests that modification of load_p (for one load) only change this load
   (same for load_q and gen_v)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,13 +113,13 @@ Native multi agents support:
 - [FIXED] some issues spotted by sonarcloud (especially attribute names)
 - [FIXED] doc about the ENV_DOES_REDISPATCHING parameters. see issue 
   https://github.com/grid2op/grid2op/issues/752 
+- [ADDED] some tests that modification of load_p (for one load) only change this load
+  (same for load_q and gen_v)
 - [IMPROVED] security in the way episode statistics are saved (to prevent malicious 
   tempering with path)
 - [IMPROVED] use df.to_numpy() instead of df.values when df is a pandas dataframe
 - [IMPROVED] grid2op parameters now uses "slots" to avoid setting incorrect values
   not used by grid2op.
-- [ADDED] some tests that modification of load_p (for one load) only change this load
-  (same for load_q and gen_v)
 
 [1.12.3] - 2026-02-04
 -----------------------

--- a/grid2op/Environment/baseEnv.py
+++ b/grid2op/Environment/baseEnv.py
@@ -2189,6 +2189,12 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         """this computes the redispaching vector, taking into account the storage units"""
         except_ = None
         valid = True
+        if not self._parameters.ENV_DOES_REDISPATCHING:
+            # env redispatching routine is asked not 
+            # to work
+            self._actual_dispatch[:] = self._target_dispatch.copy()
+            return valid, except_
+        
         mismatch = self._actual_dispatch - self._target_dispatch
         mismatch = np.abs(mismatch)
         if (
@@ -3793,7 +3799,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
             new_p, new_p_th = self._aux_apply_detachment(new_p, new_p_th)
 
             beg__redisp = time.perf_counter()
-            if (cls.redispatching_unit_commitment_availble or cls.n_storage > 0) and self._parameters.ENV_DOES_REDISPATCHING:
+            if (cls.redispatching_unit_commitment_availble or cls.n_storage > 0):
                 # this computes the "optimal" redispatching
                 # and it is also in this function that the limiting of the curtailment / storage actions
                 # is perform to make the state "feasible"
@@ -4051,10 +4057,8 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         if hasattr(self, "_viewer") and self._viewer is not None:
             self._viewer = None
             self.viewer_fig = None
-
         if hasattr(self, "backend") and self.backend is not None:
             self.backend.close()
-            del self.backend
         self.backend :Backend = None
 
         if hasattr(self, "_observation_space") and self._observation_space is not None:

--- a/grid2op/MakeEnv/MakeFromPath.py
+++ b/grid2op/MakeEnv/MakeFromPath.py
@@ -417,7 +417,7 @@ def make_from_dataset_path(
             try:
                 _check_path(grid_path_abs, "Dataset power flow solver configuration")
                 break
-            except EnvError as exc_:
+            except EnvError as exc_:  # noqa: F841
                 pass
         if grid_path_abs is None:
             raise EnvError(f"Impossible to find a grid file format supported by your backend. Your backend said it supports "
@@ -492,7 +492,7 @@ def make_from_dataset_path(
                         try:
                             int_ = int(el)
                             available_parameters_int[int_] = el
-                        except Exception as exc_:
+                        except Exception as exc_:  # noqa: F841
                             pass
                     max_ = np.max(list(available_parameters_int.keys()))
                     keys_ = available_parameters_int[max_]
@@ -552,8 +552,8 @@ def make_from_dataset_path(
 
     # Get default Voltage class
     voltage_class_cfg = ControlVoltageFromFile
-    if "voltage_class" in config_data and config_data["voltage_class"] is not None:
-        voltage_class_cfg = config_data["voltage_class"]
+    if "voltagecontroler_class" in config_data and config_data["voltagecontroler_class"] is not None:
+        voltage_class_cfg = config_data["voltagecontroler_class"]
     ### Create controler for voltages
     volagecontroler_class = _get_default_aux(
         "voltagecontroler_class",
@@ -645,7 +645,7 @@ def make_from_dataset_path(
                 # if it's in the config but is not supported by the 
                 # user, then we ignore it
                 # see https://github.com/Grid2Op/grid2op/issues/593
-                if el in dfkwargs_cfg and not el in data_feeding_kwargs_user_prov:
+                if el in dfkwargs_cfg and el not in data_feeding_kwargs_user_prov:
                     del data_feeding_kwargs_res[el]
         data_feeding_kwargs = data_feeding_kwargs_res
     # now build the chronics handler

--- a/grid2op/Parameters.py
+++ b/grid2op/Parameters.py
@@ -201,7 +201,35 @@ class Parameters:
         It defaults to ``False``.
         
     """
-
+    
+    # added in 1.12.4 to avoid 
+    __slots__ = (
+        "NO_OVERFLOW_DISCONNECTION",
+        "NB_TIMESTEP_OVERFLOW_ALLOWED",
+        "NB_TIMESTEP_RECONNECTION",
+        "NB_TIMESTEP_COOLDOWN_LINE",
+        "NB_TIMESTEP_COOLDOWN_SUB",
+        "HARD_OVERFLOW_THRESHOLD",
+        "SOFT_OVERFLOW_THRESHOLD",
+        "ENV_DC",
+        "FORECAST_DC",
+        "MAX_SUB_CHANGED",
+        "MAX_LINE_STATUS_CHANGED",
+        "IGNORE_MIN_UP_DOWN_TIME",
+        "ALLOW_DISPATCH_GEN_SWITCH_OFF",
+        "LIMIT_INFEASIBLE_CURTAILMENT_STORAGE_ACTION",
+        "INIT_STORAGE_CAPACITY",
+        "ACTIVATE_STORAGE_LOSS",
+        "ALARM_BEST_TIME",
+        "ALARM_WINDOW_SIZE",
+        "ALERT_TIME_WINDOW",
+        "MAX_SIMULATE_PER_STEP",
+        "MAX_SIMULATE_PER_EPISODE",
+        "IGNORE_INITIAL_STATE_TIME_SERIE",
+        "ENV_DOES_REDISPATCHING",
+        "STOP_EP_IF_GEN_BREAK_CONSTRAINTS"
+    )
+    
     def __init__(self, parameters_path=None):
         """
         Build an object representing the _parameters of the game.
@@ -272,6 +300,12 @@ class Parameters:
         # number of simulate
         self.MAX_SIMULATE_PER_STEP = dt_int(-1)
         self.MAX_SIMULATE_PER_EPISODE = dt_int(-1)
+                
+        self.IGNORE_INITIAL_STATE_TIME_SERIE = False
+        
+        # Added in 1.11.0 with detachement
+        self.ENV_DOES_REDISPATCHING = True
+        self.STOP_EP_IF_GEN_BREAK_CONSTRAINTS = False
 
         if parameters_path is not None:
             if os.path.isfile(parameters_path):
@@ -279,12 +313,6 @@ class Parameters:
             else:
                 warn_msg = "Parameters: the file {} is not found. Continuing with default parameters."
                 warnings.warn(warn_msg.format(parameters_path))
-                
-        self.IGNORE_INITIAL_STATE_TIME_SERIE = False
-        
-        # Added in 1.11.0 with detachement
-        self.ENV_DOES_REDISPATCHING = True
-        self.STOP_EP_IF_GEN_BREAK_CONSTRAINTS = False
 
     @staticmethod
     def _isok_txt(arg):
@@ -436,7 +464,7 @@ class Parameters:
         if "STOP_EP_IF_GEN_BREAK_CONSTRAINTS" in dict_:
             self.STOP_EP_IF_GEN_BREAK_CONSTRAINTS = Parameters._isok_txt(dict_["STOP_EP_IF_GEN_BREAK_CONSTRAINTS"])
         
-        authorized_keys = set(self.__dict__.keys())
+        authorized_keys = set(type(self).__slots__)
         authorized_keys = authorized_keys | {
             "NB_TIMESTEP_POWERFLOW_ALLOWED",
             "NB_TIMESTEP_TOPOLOGY_REMODIF",

--- a/grid2op/Parameters.py
+++ b/grid2op/Parameters.py
@@ -168,6 +168,13 @@ class Parameters:
         
         It is ``True`` by default and for all grid2op environment before version 1.11.0
         
+        .. danger::
+            TL;DR
+            
+            Keep it the default (True) if you want your agent to be able to do redispatching
+            correctly, unless you have specific reason not to let the environment
+            adjust the offer / demand balance.
+        
         .. versionadded: 1.11.0
         
         .. note::
@@ -175,10 +182,11 @@ class Parameters:
             will be highly dependant on the backend (for example results might differ
             between using lightsim2grid or pypowsybl2grid) and more importantly between the
             parameters of the backend
-            
-        Setting this parameter to `False` is not advised if your agent really depends on redispatching, curtailment
-        or actions on storage units OR if your backend does not have a distributed slack (at least). (note
-        that we do not recommend to use it even if your backend has a distributed slack).
+        
+        .. warning::
+            Setting this parameter to `False` is not advised if your agent really depends on redispatching, curtailment
+            or actions on storage units OR if your backend does not have a distributed slack (at least). (note
+            that we do not recommend to use it even if your backend has a distributed slack).
         
         Furthermore, if you consider doing a lot of "detachment" / "shedding" / "curtailment"
         on the loads or generator, it's best to avoid setting this flag to `False`.

--- a/grid2op/Space/GridObjects.py
+++ b/grid2op/Space/GridObjects.py
@@ -2346,7 +2346,6 @@ class GridObjects:
                 "Mismatch between storage_to_subid, "
                 "storage_to_sub_pos and storage_pos_topo_vect"
             )
-
         # no empty bus: at least one element should be present on each bus
         if (cls.sub_info < 1).any():
             if not grid2op.Space.space_utils._WARNING_ISSUED_FOR_SUB_NO_ELEM:

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -1115,7 +1115,6 @@ class AAATestBackendAPI(MakeBackend):
         backend = self.aux_make_backend()
         cls = type(backend)
         # a non connected grid
-        action = cls._complete_action_class()
         # action.update({"set_bus": {"lines_or_id": [(17, 2)],
         #                            "lines_ex_id": [(7, 2), (14, 2)]}})
         # build an action such that a line is alone (bus 2) at both its ends
@@ -1135,7 +1134,10 @@ class AAATestBackendAPI(MakeBackend):
             warnings.warn("Impossible to build a non connected subgraph consisting of a powerline isolated at both its ends "
                           "without disconnected a generator or a load. This test cannot continue.")
             return
-        action.update({"set_bus": {"lines_or_id": [(found_l_id, 2)], "lines_ex_id": [(found_l_id, 2)]}})
+        act_dict = {"set_bus": {"lines_or_id": [(found_l_id, 2)], "lines_ex_id": [(found_l_id, 2)]}}
+        
+        action = cls._complete_action_class()
+        action.update(act_dict)
         bk_act = cls.my_bk_act_class()
         bk_act += action
         backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
@@ -1149,9 +1151,8 @@ class AAATestBackendAPI(MakeBackend):
         
         # a non connected grid
         backend.reset_public(self.get_path(), self.get_casefile())
-        action = type(backend)._complete_action_class()
-        action.update({"set_bus": {"lines_or_id": [(17, 2)],
-                                   "lines_ex_id": [(7, 2), (14, 2)]}})
+        action = cls._complete_action_class()
+        action.update(act_dict)
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
         backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
@@ -1906,22 +1907,34 @@ class AAATestBackendAPI(MakeBackend):
             self.skipTest("Cannot perform this test as your backend does not appear "
                           "to support the `detachment` information: a disconnect load "
                           "or generator is necessarily causing a game over.")
-            
-        # a load is disconnected
+        
+        res = backend.runpf(is_dc=True)  
+        assert len(res) == 2
+        assert res[0], "your backend should have converged (DC)"
+        assert res[1] is None, "your backend should have converged (DC)"
+        
+        # find an id of a generator to disconnect
+        # here I take tha smallest connected one
+        gen_p, gen_q, gen_v = backend.generators_info()
+        gen_p_modif = np.abs(gen_p)
+        gen_p_modif[gen_p_modif <= 1e-5] = np.max(gen_p_modif) + 1.
+        gen_id = int(gen_p_modif.argmin())
+        
+        # a generator is disconnected
         action = type(backend)._complete_action_class()
-        action.update({"set_bus": {"generators_id": [(0, -1)]}})
+        action.update({"set_bus": {"generators_id": [(gen_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
         backend.apply_action_public(bk_act)
         # DC
         res = backend.runpf(is_dc=True)  
         assert len(res) == 2
-        assert res[0], "your backend should have converged with disconnect of gen 0 (DC)"
-        assert res[1] is None, "your backend should have converged with disconnect of gen 0 (DC)"
+        assert res[0], f"your backend should have converged with disconnect of gen {gen_id} (DC)"
+        assert res[1] is None, "your backend should have converged with disconnect of gen {gen_id} (DC)"
         gen_p, gen_q, gen_v = backend.generators_info()
-        assert np.abs(gen_p[0]) <= 1e-8, f"disconnected gen should have a p of 0, found {gen_p[0]} (DC)"
-        assert np.abs(gen_q[0]) <= 1e-8, f"disconnected gen should have a q of 0, found {gen_q[0]} (DC)"
-        assert np.abs(gen_v[0]) <= 1e-8, f"disconnected gen should have a v of 0, found {gen_v[0]} (DC)"
+        assert np.abs(gen_p[gen_id]) <= 1e-8, f"disconnected gen {gen_id} should have a p of 0, found {gen_p[gen_id]} (DC)"
+        assert np.abs(gen_q[gen_id]) <= 1e-8, f"disconnected gen {gen_id} should have a q of 0, found {gen_q[gen_id]} (DC)"
+        assert np.abs(gen_v[gen_id]) <= 1e-8, f"disconnected gen {gen_id} should have a v of 0, found {gen_v[gen_id]} (DC)"
         
         # AC
         res = backend.runpf(is_dc=False)  
@@ -1929,9 +1942,9 @@ class AAATestBackendAPI(MakeBackend):
         assert res[0], "your backend should have converged with disconnect of gen 0 (AC)"
         assert res[1] is None, "your backend should have converged with disconnect of gen 0 (AC)"
         gen_p, gen_q, gen_v = backend.generators_info()
-        assert np.abs(gen_p[0]) <= 1e-8, f"disconnected gen should have a p of 0, found {gen_p[0]} (AC)"
-        assert np.abs(gen_q[0]) <= 1e-8, f"disconnected gen should have a q of 0, found {gen_q[0]} (AC)"
-        assert np.abs(gen_v[0]) <= 1e-8, f"disconnected gen should have a voltage set to 0, found {gen_v[0]} (AC)"
+        assert np.abs(gen_p[gen_id]) <= 1e-8, f"disconnected gen should have a p of 0, found {gen_p[gen_id]} (AC)"
+        assert np.abs(gen_q[gen_id]) <= 1e-8, f"disconnected gen should have a q of 0, found {gen_q[gen_id]} (AC)"
+        assert np.abs(gen_v[gen_id]) <= 1e-8, f"disconnected gen should have a voltage set to 0, found {gen_v[gen_id]} (AC)"
         
     def test_36_shvnkv_present_if_shunt_supported(self):
         """

--- a/grid2op/tests/test_Environment.py
+++ b/grid2op/tests/test_Environment.py
@@ -733,7 +733,7 @@ class BaseTestCascadingFailure:
             warnings.filterwarnings("ignore")
             params = Parameters()
             params.MAX_SUB_CHANGED = 0
-            params.NB_TIMESTEP_POWERFLOW_ALLOWED = 2
+            params.NB_TIMESTEP_OVERFLOW_ALLOWED = 2
             rules = DefaultRules
             self.env = grid2op.make(
                 "rte_case14_test",

--- a/grid2op/tests/test_Rules.py
+++ b/grid2op/tests/test_Rules.py
@@ -6,21 +6,35 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
 
-import pdb
+import pdb  # noqa: F401
+import os
+import numpy as np
 import warnings
 import unittest
 
 from grid2op.Observation.baseObservation import BaseObservation
-from grid2op.tests.helper_path_test import *
+from grid2op.tests.helper_path_test import (
+    PATH_DATA_TEST_PP,
+    PATH_CHRONICS,
+    
+)
 
 import grid2op
-from grid2op.dtypes import dt_int, dt_bool, dt_float
-from grid2op.Exceptions import *
+from grid2op.dtypes import dt_int, dt_bool
+from grid2op.Exceptions import (
+    IllegalAction,
+)
 from grid2op.Environment import Environment
 from grid2op.Backend import PandaPowerBackend
 from grid2op.Parameters import Parameters
 from grid2op.Chronics import ChronicsHandler, GridStateFromFile
-from grid2op.Rules import *
+from grid2op.Rules import (
+    RulesChecker,
+    LookParam,
+    PreventReconnection,
+    DefaultRules,
+    AlwaysLegal
+)
 
 
 class TestLoadingBackendFunc(unittest.TestCase):
@@ -302,13 +316,13 @@ class TestLoadingBackendFunc(unittest.TestCase):
         )
 
     def test_linereactionnable_throw(self):
-        id_1 = 1
-        id_2 = 12
+        id_1 = 1  # noqa: F841
+        id_2 = 12  # noqa: F841
         id_line = 17
         id_line2 = 15
 
-        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)
-        arr2 = np.array([1, 1, 2, 2], dtype=dt_int)
+        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)  # noqa: F841
+        arr2 = np.array([1, 1, 2, 2], dtype=dt_int)  # noqa: F841
         arr_line1 = np.full(self.helper_action.n_line, fill_value=False, dtype=dt_bool)
         arr_line1[id_line] = True
 
@@ -335,13 +349,13 @@ class TestLoadingBackendFunc(unittest.TestCase):
             pass
 
     def test_linereactionnable_nothrow(self):
-        id_1 = 1
-        id_2 = 12
+        id_1 = 1  # noqa: F841
+        id_2 = 12  # noqa: F841
         id_line = 17
         id_line2 = 15
 
-        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)
-        arr2 = np.array([1, 1, 2, 2], dtype=dt_int)
+        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)  # noqa: F841
+        arr2 = np.array([1, 1, 2, 2], dtype=dt_int)  # noqa: F841
         arr_line1 = np.full(self.helper_action.n_line, fill_value=False, dtype=dt_bool)
         arr_line1[id_line] = True
 
@@ -367,13 +381,13 @@ class TestLoadingBackendFunc(unittest.TestCase):
         )
 
     def test_linereactionnable_throw_longerperiod(self):
-        id_1 = 1
-        id_2 = 12
+        id_1 = 1  # noqa: F841
+        id_2 = 12  # noqa: F841
         id_line = 17
         id_line2 = 15
 
-        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)
-        arr2 = np.array([1, 1, 2, 2], dtype=dt_int)
+        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)  # noqa: F841
+        arr2 = np.array([1, 1, 2, 2], dtype=dt_int)  # noqa: F841
         arr_line1 = np.full(self.helper_action.n_line, fill_value=False, dtype=dt_bool)
         arr_line1[id_line] = True
 
@@ -381,7 +395,7 @@ class TestLoadingBackendFunc(unittest.TestCase):
         arr_line2[id_line2] = -1
 
         self.env._max_timestep_line_status_deactivated = 2
-        self.env._parameters.NB_TIMESTEP_LINE_STATUS_REMODIF = 2
+        self.env._parameters.NB_TIMESTEP_COOLDOWN_LINE = 2
 
         self.helper_action.legal_action = RulesChecker(
             legalActClass=PreventReconnection
@@ -407,12 +421,12 @@ class TestLoadingBackendFunc(unittest.TestCase):
             pass
 
     def test_toporeactionnable_throw(self):
-        id_1 = 1
+        id_1 = 1  # noqa: F841
         id_2 = 12
         id_line = 17
         id_line2 = 15
 
-        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)
+        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)  # noqa: F841
         arr2 = np.array([1, 1, 2, 2], dtype=dt_int)
         arr_line1 = np.full(self.helper_action.n_line, fill_value=False, dtype=dt_bool)
         arr_line1[id_line] = True
@@ -444,12 +458,12 @@ class TestLoadingBackendFunc(unittest.TestCase):
             pass
 
     def test_toporeactionnable_nothrow(self):
-        id_1 = 1
+        id_1 = 1  # noqa: F841
         id_2 = 12
         id_line = 17
         id_line2 = 15
 
-        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)
+        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)  # noqa: F841
         arr2 = np.array([1, 1, 2, 2], dtype=dt_int)
         arr_line1 = np.full(self.helper_action.n_line, fill_value=False, dtype=dt_bool)
         arr_line1[id_line] = True
@@ -480,12 +494,12 @@ class TestLoadingBackendFunc(unittest.TestCase):
         )
 
     def test_toporeactionnable_throw_longerperiod(self):
-        id_1 = 1
+        id_1 = 1  # noqa: F841
         id_2 = 12
         id_line = 17
         id_line2 = 15
 
-        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)
+        arr1 = np.array([False, False, False, True, True, True], dtype=dt_bool)  # noqa: F841
         arr2 = np.array([1, 1, 2, 2], dtype=dt_int)
         arr_line1 = np.full(self.helper_action.n_line, fill_value=False, dtype=dt_bool)
         arr_line1[id_line] = True
@@ -606,8 +620,8 @@ class TestReconnectionsLegality(unittest.TestCase):
         disco_act = env_case2.action_space.disconnect_powerline(line_id=line_id)
         obs, reward, done, info = env_case2.step(disco_act)
         # Line has been disconnected
-        assert info["is_illegal"] == False
-        assert done == False
+        assert not info["is_illegal"]
+        assert not done
         assert np.sum(obs.line_status) == (env_case2.n_line - 1)
 
         # Reconnect the line
@@ -616,8 +630,8 @@ class TestReconnectionsLegality(unittest.TestCase):
         )
         obs, reward, done, info = env_case2.step(reco_act)
         # Check reconnecting is legal
-        assert info["is_illegal"] == False
-        assert done == False
+        assert not info["is_illegal"]
+        assert not done
         # Check line has been reconnected
         assert np.sum(obs.line_status) == (env_case2.n_line)
 
@@ -644,7 +658,7 @@ class TestReconnectionsLegality(unittest.TestCase):
         obs, reward, done, info = env.step(disco_act)
         assert obs.rho[l_id] == 0.0
         assert obs.time_before_cooldown_line[l_id] == 3
-        assert env.backend._grid.line.iloc[l_id]["in_service"] == False
+        assert not env.backend._grid.line.iloc[l_id]["in_service"]
 
         # i have a cooldown to 2 so i cannot reconnect it
         assert obs.time_before_cooldown_line[l_id] == 3
@@ -652,29 +666,29 @@ class TestReconnectionsLegality(unittest.TestCase):
         assert obs.rho[l_id] == 0.0
         assert info["is_illegal"]
         assert obs.time_before_cooldown_line[l_id] == 2
-        assert env.backend._grid.line.iloc[l_id]["in_service"] == False
+        assert not env.backend._grid.line.iloc[l_id]["in_service"]
 
         # this is not supposed to reconnect it either (cooldown)
         assert obs.time_before_cooldown_line[l_id] == 2
         obs, reward, done, info = env.step(set_or_1_act)
         # assert info["is_illegal"]
-        assert env.backend._grid.line.iloc[l_id]["in_service"] == False
+        assert not env.backend._grid.line.iloc[l_id]["in_service"]
         assert obs.rho[l_id] == 0.0
         assert obs.time_before_cooldown_line[l_id] == 1
-        assert env.backend._grid.line.iloc[l_id]["in_service"] == False
+        assert not env.backend._grid.line.iloc[l_id]["in_service"]
 
         # and neither is that (cooldown)
         assert obs.time_before_cooldown_line[l_id] == 1
         obs, reward, done, info = env.step(set_ex_1_act)
         assert obs.rho[l_id] == 0.0
         assert obs.time_before_cooldown_line[l_id] == 0
-        assert env.backend._grid.line.iloc[l_id]["in_service"] == False
+        assert not env.backend._grid.line.iloc[l_id]["in_service"]
 
         # and now i can reconnect
         obs, reward, done, info = env.step(reco_act)
         assert obs.rho[l_id] != 0.0
         assert obs.time_before_cooldown_line[l_id] == 3
-        assert env.backend._grid.line.iloc[l_id]["in_service"] == True
+        assert env.backend._grid.line.iloc[l_id]["in_service"]
 
 
 class TestSubstationImpactLegality(unittest.TestCase):
@@ -714,7 +728,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         bus_action = self.env.action_space({"set_bus": {"lines_ex_id": [(LINE_ID, 2)]}})
         # Make sure its illegal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == True
+        assert info["is_illegal"]
 
     def test_two_setbus_line_one_sub_allowed_is_illegal(self):
         # Set 1 allowed substation changes
@@ -727,7 +741,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         )
         # Make sure its illegal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == True
+        assert info["is_illegal"]
 
     def test_one_setbus_line_one_sub_allowed_is_legal(self):
         # Set 1 allowed substation changes
@@ -739,7 +753,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         )
         # Make sure its legal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == False
+        assert not info["is_illegal"]
 
     def test_two_setbus_line_two_sub_allowed_is_legal(self):
         # Set 2 allowed substation changes
@@ -750,9 +764,9 @@ class TestSubstationImpactLegality(unittest.TestCase):
         bus_action = self.env.action_space(
             {"set_bus": {"lines_ex_id": [(LINE1_ID, 2), (LINE2_ID, 2)]}}
         )
-        # Make sure its legal
+        # Make sure its illegal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == False
+        assert not info["is_illegal"]
 
     def test_changebus_line_no_sub_allowed_is_illegal(self):
         # Set 0 allowed substation changes
@@ -762,7 +776,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         bus_action = self.env.action_space({"change_bus": {"lines_ex_id": [LINE_ID]}})
         # Make sure its illegal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == True
+        assert info["is_illegal"]
 
     def test_changebus_line_one_sub_allowed_is_legal(self):
         # Set 1 allowed substation changes
@@ -772,7 +786,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         bus_action = self.env.action_space({"change_bus": {"lines_ex_id": [LINE_ID]}})
         # Make sure its legal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == False
+        assert not info["is_illegal"]
 
     def test_changebus_two_line_one_sub_allowed_is_illegal(self):
         # Set 1 allowed substation changes
@@ -785,7 +799,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         )
         # Make sure its illegal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == True
+        assert info["is_illegal"]
 
     def test_changebus_two_line_two_sub_allowed_is_legal(self):
         # Set 2 allowed substation changes
@@ -798,7 +812,7 @@ class TestSubstationImpactLegality(unittest.TestCase):
         )
         # Make sure its legal
         info = self._aux_do_act(bus_action)
-        assert info["is_illegal"] == False
+        assert not info["is_illegal"]
 
 
 class TestSubstationImpactLegalitySimulate(TestSubstationImpactLegality):

--- a/grid2op/tests/test_issue_752.py
+++ b/grid2op/tests/test_issue_752.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+# See AUTHORS.txt and https://github.com/Grid2Op/grid2op/pull/319
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+
+import warnings
+import grid2op
+import numpy as np
+import unittest
+
+from grid2op.Action import CompleteAction
+from grid2op.Observation import CompleteObservation
+
+
+class TestIssue752(unittest.TestCase):
+    def setUp(self):
+        env_name = "educ_case14_storage"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make(env_name,
+                                    test=True,
+                                    observation_class=CompleteObservation,
+                                    action_class=CompleteAction,
+                                    _add_to_name=f"{type(self).__name__}")
+        param = self.env.parameters
+        param.ENV_DOES_REDISPATCHING = False
+        self.env.change_parameters(param)
+        self.obs = self.env.reset(seed=0, options={"time serie id": 0})
+        return super().setUp()
+    
+    def tearDown(self):
+        self.env.close()
+        return super().tearDown()
+    
+    def test_issue(self):            
+        obs, reward, done, info = self.env.step(self.env.action_space({"redispatch": [(0, -1)]}))
+        assert obs.target_dispatch[0] == -1
+        assert obs.actual_dispatch[0] == -1
+    
+    def test_storage(self):
+        obs, reward, done, info = self.env.step(self.env.action_space({"set_storage": [(0, -1)]}))
+        assert (np.abs(obs.target_dispatch) < 1e-6).all()
+        assert (np.abs(obs.actual_dispatch) < 1e-6).all()
+        assert obs.storage_power[0] == -1
+        assert np.abs(obs.storage_charge[0] - (obs.storage_Emax[0] * 0.5 - 1/12 - obs.storage_loss[0] /12) ) < 1e-6
+        assert np.abs(obs.storage_charge[1] - (obs.storage_Emax[1] * 0.5 - obs.storage_loss[1] /12) ) < 1e-6
+        
+    def test_curtailment(self):
+        obs, reward, done, info = self.env.step(self.env.action_space({"curtail": [(2, 0.20)]}))
+        assert (np.abs(obs.target_dispatch) < 1e-6).all()
+        assert (np.abs(obs.actual_dispatch) < 1e-6).all()
+        assert (obs.gen_p[2] - obs.gen_pmax[2] * 0.2) < 1e-6  # check curtailment is correctly applied
+        
+        obs, reward, done, info = self.env.step(self.env.action_space({"curtail": [(2, 1.)]}))
+        assert (np.abs(obs.target_dispatch) < 1e-6).all()
+        assert (np.abs(obs.actual_dispatch) < 1e-6).all()
+        assert (obs.gen_p[2] - 17.) < 1e-6  # check curtailment is not put to 1. (target) but corresponds to the correct value


### PR DESCRIPTION
- [BREAKING] the behaviour of grid2op environment when ENV_DOES_REDISPATCHING
  flag is turned on is changed and is now exactly the one 
  described in the doc (before it completly skipped the redispathcing / curtailment 
  storage)
- [FIXED] copy on write issues in PandaPowerBackend
- [FIXED] a bug causing https://github.com/Grid2op/lightsim2grid/issues/128
- [FIXED] some warnings in the docstrings (escaped character)
- [FIXED] some issues spotted by sonarcloud (especially attribute names)
- [FIXED] doc about the ENV_DOES_REDISPATCHING parameters. see issue 
  https://github.com/grid2op/grid2op/issues/752 
- [IMPROVED] security in the way episode statistics are saved (to prevent malicious 
  tempering with path)
- [IMPROVED] use df.to_numpy() instead of df.values when df is a pandas dataframe
- [IMPROVED] grid2op parameters now uses "slots" to avoid setting incorrect values
  not used by grid2op.
- [ADDED] some tests that modification of load_p (for one load) only change this load
  (same for load_q and gen_v)